### PR TITLE
Use correct Dockerfile keyword

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.3.1-slim
 ENV PHANTOM_JS_VERSION 2.1.1
 ENV PHANTOM_JS_PACKAGE phantomjs-$PHANTOM_JS_VERSION-linux-x86_64
-PORT 3000
+EXPOSE 3000
 
 RUN apt-get update -qq &&\
     apt-get install -y wget libpq-dev git-core postgresql-client build-essential --no-install-recommends


### PR DESCRIPTION
The Dockerfile was written using `PORT`, when it should use `EXPOSE`(https://docs.docker.com/engine/reference/builder/#/expose)
