### PR TITLE
Increased API loading performance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,10 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def serialize(target, serializer:)
+    serializer.new(target).serialized_json
+  end
+
   def layout_by_resource
     devise_controller? ? 'authentication' : 'application'
   end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -6,12 +6,12 @@ class CategoriesController < ApplicationController
     @categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @categories
 
-    render json: @categories
+    render json: serialize(@categories)
   end
 
   # GET /categories/1
   def show
-    render json: @category
+    render json: serialize(@category)
   end
 
   # POST /categories
@@ -21,7 +21,7 @@ class CategoriesController < ApplicationController
     authorize @category
 
     if @category.save
-      render json: @category, status: :created, location: @category
+      render json: serialize(@category), status: :created, location: @category
     else
       render json: @category.errors, status: :unprocessable_entity
     end
@@ -32,7 +32,7 @@ class CategoriesController < ApplicationController
     if params[:category][:updated_at] && DateTime.parse(params[:category][:updated_at]).to_i != @category.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: @category if @category.update_attributes!(permitted_attributes(@category))
+    render json: serialize(@category) if @category.update_attributes!(permitted_attributes(@category))
   end
 
   # DELETE /categories/1
@@ -50,5 +50,9 @@ class CategoriesController < ApplicationController
 
   def base_object
     Category.with_versions
+  end
+
+  def serialize(target, serializer: CategorySerializer)
+    super
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -3,7 +3,7 @@ class CategoriesController < ApplicationController
 
   # GET /categories
   def index
-    @categories = policy_scope(Category).order(created_at: :desc).page(params[:page])
+    @categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @categories
 
     render json: @categories
@@ -44,7 +44,11 @@ class CategoriesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_category
-    @category = policy_scope(Category).find(params[:id])
+    @category = policy_scope(base_object).find(params[:id])
     authorize @category
+  end
+
+  def base_object
+    Category.with_versions
   end
 end

--- a/app/controllers/due_dates_controller.rb
+++ b/app/controllers/due_dates_controller.rb
@@ -6,12 +6,12 @@ class DueDatesController < ApplicationController
     @due_dates = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @due_dates
 
-    render json: @due_dates
+    render json: serialize(@due_dates)
   end
 
   # GET /due_dates/1
   def show
-    render json: @due_date
+    render json: serialize(@due_date)
   end
 
   # POST /due_dates
@@ -21,7 +21,7 @@ class DueDatesController < ApplicationController
     authorize @due_date
 
     if @due_date.save
-      render json: @due_date, status: :created, location: @due_date
+      render json: serialize(@due_date), status: :created, location: @due_date
     else
       render json: @due_date.errors, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class DueDatesController < ApplicationController
 
   # PATCH/PUT /due_dates/1
   def update
-    render json: @due_date if @due_date.update_attributes!(permitted_attributes(@due_date))
+    render json: serialize(@due_date) if @due_date.update_attributes!(permitted_attributes(@due_date))
   end
 
   # DELETE /due_dates/1
@@ -47,5 +47,9 @@ class DueDatesController < ApplicationController
 
   def base_object
     DueDate.with_versions
+  end
+
+  def serialize(target, serializer: DueDateSerializer)
+    super
   end
 end

--- a/app/controllers/due_dates_controller.rb
+++ b/app/controllers/due_dates_controller.rb
@@ -3,7 +3,7 @@ class DueDatesController < ApplicationController
 
   # GET /due_dates
   def index
-    @due_dates = policy_scope(DueDate).order(created_at: :desc).page(params[:page])
+    @due_dates = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @due_dates
 
     render json: @due_dates
@@ -41,7 +41,11 @@ class DueDatesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_due_date
-    @due_date = policy_scope(DueDate).find(params[:id])
+    @due_date = policy_scope(base_object).find(params[:id])
     authorize @due_date
+  end
+
+  def base_object
+    DueDate.with_versions
   end
 end

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -44,9 +44,11 @@ class IndicatorsController < ApplicationController
   private
 
   def base_object
-    return Measure.find(params[:measure_id]).indicators if params[:measure_id]
-
-    Indicator
+    if params[:measure_id]
+      Measure.find(params[:measure_id]).indicators
+    else
+      Indicator
+    end.with_versions
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -3,7 +3,7 @@ class IndicatorsController < ApplicationController
 
   # GET /indicators
   def index
-    @indicators = policy_scope(base_object).order(created_at: :desc).page(params[:page])
+    @indicators = policy_scope(base_object).with_versions.order(created_at: :desc).page(params[:page])
     authorize @indicators
 
     render json: serialize(@indicators)
@@ -51,7 +51,7 @@ class IndicatorsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_indicator
-    @indicator = policy_scope(base_object).find(params[:id])
+    @indicator = policy_scope(base_object).with_versions.find(params[:id])
     authorize @indicator
   end
 

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -57,7 +57,7 @@ class IndicatorsController < ApplicationController
     authorize @indicator
   end
 
-  def serialize(target)
-    IndicatorSerializer.new(target).serialized_json
+  def serialize(target, serializer: IndicatorSerializer)
+    super
   end
 end

--- a/app/controllers/measure_categories_controller.rb
+++ b/app/controllers/measure_categories_controller.rb
@@ -3,7 +3,7 @@ class MeasureCategoriesController < ApplicationController
 
   # GET /measure_categories
   def index
-    @measure_categories = policy_scope(MeasureCategory).order(created_at: :desc).page(params[:page])
+    @measure_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @measure_categories
 
     render json: @measure_categories
@@ -41,7 +41,11 @@ class MeasureCategoriesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_measure_category
-    @measure_category = policy_scope(MeasureCategory).find(params[:id])
+    @measure_category = policy_scope(base_object).find(params[:id])
     authorize @measure_category
+  end
+
+  def base_object
+    MeasureCategory
   end
 end

--- a/app/controllers/measure_categories_controller.rb
+++ b/app/controllers/measure_categories_controller.rb
@@ -6,12 +6,12 @@ class MeasureCategoriesController < ApplicationController
     @measure_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @measure_categories
 
-    render json: @measure_categories
+    render json: serialize(@measure_categories)
   end
 
   # GET /measure_categories/1
   def show
-    render json: @measure_category
+    render json: serialize(@measure_category)
   end
 
   # POST /measure_categories
@@ -21,7 +21,7 @@ class MeasureCategoriesController < ApplicationController
     authorize @measure_category
 
     if @measure_category.save
-      render json: @measure_category, status: :created, location: @measure_category
+      render json: serialize(@measure_category), status: :created, location: @measure_category
     else
       render json: @measure_category.errors, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class MeasureCategoriesController < ApplicationController
 
   # PATCH/PUT /measure_categories/1
   def update
-    render json: @measure_category if @measure_category.update_attributes!(permitted_attributes(@measure_category))
+    render json: serialize(@measure_category) if @measure_category.update_attributes!(permitted_attributes(@measure_category))
   end
 
   # DELETE /measure_categories/1
@@ -47,5 +47,9 @@ class MeasureCategoriesController < ApplicationController
 
   def base_object
     MeasureCategory
+  end
+
+  def serialize(target, serializer: MeasureCategorySerializer)
+    super
   end
 end

--- a/app/controllers/measure_indicators_controller.rb
+++ b/app/controllers/measure_indicators_controller.rb
@@ -3,7 +3,7 @@ class MeasureIndicatorsController < ApplicationController
 
   # GET /measure_indicators
   def index
-    @measure_indicators = policy_scope(MeasureIndicator).order(created_at: :desc).page(params[:page])
+    @measure_indicators = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @measure_indicators
 
     render json: @measure_indicators
@@ -41,7 +41,11 @@ class MeasureIndicatorsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_measure_indicator
-    @measure_indicator = policy_scope(MeasureIndicator).find(params[:id])
+    @measure_indicator = policy_scope(base_object).find(params[:id])
     authorize @measure_indicator
+  end
+
+  def base_object
+    MeasureIndicator
   end
 end

--- a/app/controllers/measure_indicators_controller.rb
+++ b/app/controllers/measure_indicators_controller.rb
@@ -6,12 +6,12 @@ class MeasureIndicatorsController < ApplicationController
     @measure_indicators = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @measure_indicators
 
-    render json: @measure_indicators
+    render json: serialize(@measure_indicators)
   end
 
   # GET /measure_indicators/1
   def show
-    render json: @measure_indicator
+    render json: serialize(@measure_indicator)
   end
 
   # POST /measure_indicators
@@ -21,7 +21,7 @@ class MeasureIndicatorsController < ApplicationController
     authorize @measure_indicator
 
     if @measure_indicator.save
-      render json: @measure_indicator, status: :created, location: @measure_indicator
+      render json: serialize(@measure_indicator), status: :created, location: @measure_indicator
     else
       render json: @measure_indicator.errors, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class MeasureIndicatorsController < ApplicationController
 
   # PATCH/PUT /measure_indicators/1
   def update
-    render json: @measure_indicator if @measure_indicator.update_attributes!(permitted_attributes(@measure_indicator))
+    render json: serialize(@measure_indicator) if @measure_indicator.update_attributes!(permitted_attributes(@measure_indicator))
   end
 
   # DELETE /measure_indicators/1
@@ -47,5 +47,9 @@ class MeasureIndicatorsController < ApplicationController
 
   def base_object
     MeasureIndicator
+  end
+
+  def serialize(target, serializer: MeasureIndicatorSerializer)
+    super
   end
 end

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -61,7 +61,7 @@ class MeasuresController < ApplicationController
     authorize @measure
   end
 
-  def serialize(target)
-    MeasureSerializer.new(target).serialized_json
+  def serialize(target, serializer: MeasureSerializer)
+    super
   end
 end

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -44,11 +44,15 @@ class MeasuresController < ApplicationController
   private
 
   def base_object
-    return Category.find(params[:category_id]).measures if params[:category_id]
-    return Recommendation.find(params[:recommendation_id]).measures if params[:recommendation_id]
-    return Indicator.find(params[:indicator_id]).measures if params[:indicator_id]
-
-    Measure
+    if params[:category_id]
+      Category.find(params[:category_id]).measures
+    elsif params[:recommendation_id]
+      Recommendation.find(params[:recommendation_id]).measures
+    elsif params[:indicator_id]
+      Indicator.find(params[:indicator_id]).measures
+    else
+      Measure
+    end.with_versions
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -7,12 +7,12 @@ class MeasuresController < ApplicationController
     @measures = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @measures
 
-    render json: @measures
+    render json: serialize(@measures)
   end
 
   # GET /measures/1
   def show
-    render json: @measure
+    render json: serialize(@measure)
   end
 
   # POST /measures
@@ -22,7 +22,7 @@ class MeasuresController < ApplicationController
     authorize @measure
 
     if @measure.save
-      render json: @measure, status: :created, location: @measure
+      render json: serialize(@measure), status: :created, location: @measure
     else
       render json: @measure.errors, status: :unprocessable_entity
     end
@@ -33,7 +33,7 @@ class MeasuresController < ApplicationController
     if params[:measure][:updated_at] && DateTime.parse(params[:measure][:updated_at]).to_i != @measure.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: @measure if @measure.update_attributes!(permitted_attributes(@measure))
+    render json: serialize(@measure) if @measure.update_attributes!(permitted_attributes(@measure))
   end
 
   # DELETE /measures/1
@@ -59,5 +59,9 @@ class MeasuresController < ApplicationController
   def set_and_authorize_measure
     @measure = policy_scope(base_object).find(params[:id])
     authorize @measure
+  end
+
+  def serialize(target)
+    MeasureSerializer.new(target).serialized_json
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,12 +6,12 @@ class PagesController < ApplicationController
     @pages = policy_scope(base_object).order(created_at: :desc)
     authorize @pages
 
-    render json: @pages
+    render json: serialize(@pages)
   end
 
   # GET /pages/1
   def show
-    render json: @page
+    render json: serialize(@page)
   end
 
   # POST /pages
@@ -21,7 +21,7 @@ class PagesController < ApplicationController
     authorize @page
 
     if @page.save
-      render json: @page, status: :created, location: @page
+      render json: serialize(@page), status: :created, location: @page
     else
       render json: @page.errors, status: :unprocessable_entity
     end
@@ -32,7 +32,7 @@ class PagesController < ApplicationController
     if params[:page][:updated_at] && DateTime.parse(params[:page][:updated_at]).to_i != @page.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: @page if @page.update_attributes!(permitted_attributes(@page))
+    render json: serialize(@page) if @page.update_attributes!(permitted_attributes(@page))
   end
 
   # DELETE /pages/1
@@ -50,5 +50,9 @@ class PagesController < ApplicationController
 
   def base_object
     Page.with_versions
+  end
+
+  def serialize(target, serializer: PageSerializer)
+    super
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,7 @@ class PagesController < ApplicationController
 
   # GET /pages
   def index
-    @pages = policy_scope(Page).order(created_at: :desc)
+    @pages = policy_scope(base_object).order(created_at: :desc)
     authorize @pages
 
     render json: @pages
@@ -44,7 +44,11 @@ class PagesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_page
-    @page = policy_scope(Page).find(params[:id])
+    @page = policy_scope(base_object).find(params[:id])
     authorize @page
+  end
+
+  def base_object
+    Page.with_versions
   end
 end

--- a/app/controllers/progress_reports_controller.rb
+++ b/app/controllers/progress_reports_controller.rb
@@ -4,7 +4,7 @@ class ProgressReportsController < ApplicationController
 
   # GET /progress_reports
   def index
-    @progress_reports = policy_scope(ProgressReport).order(created_at: :desc).page(params[:page])
+    @progress_reports = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @progress_reports
 
     render json: @progress_reports
@@ -45,7 +45,11 @@ class ProgressReportsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_progress_report
-    @progress_report = policy_scope(ProgressReport).find(params[:id])
+    @progress_report = policy_scope(base_object).find(params[:id])
     authorize @progress_report
+  end
+
+  def base_object
+    ProgressReport.with_versions
   end
 end

--- a/app/controllers/progress_reports_controller.rb
+++ b/app/controllers/progress_reports_controller.rb
@@ -7,12 +7,12 @@ class ProgressReportsController < ApplicationController
     @progress_reports = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @progress_reports
 
-    render json: @progress_reports
+    render json: serialize(@progress_reports)
   end
 
   # GET /progress_reports/1
   def show
-    render json: @progress_report
+    render json: serialize(@progress_report)
   end
 
   # POST /progress_reports
@@ -22,7 +22,7 @@ class ProgressReportsController < ApplicationController
     authorize @progress_report
 
     if @progress_report.save
-      render json: @progress_report, status: :created, location: @progress_report
+      render json: serialize(@progress_report), status: :created, location: @progress_report
     else
       render json: @progress_report.errors, status: :unprocessable_entity
     end
@@ -33,7 +33,7 @@ class ProgressReportsController < ApplicationController
     if params[:progress_report][:updated_at] && DateTime.parse(params[:progress_report][:updated_at]).to_i != @progress_report.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: @progress_report if @progress_report.update_attributes!(permitted_attributes(@progress_report))
+    render json: serialize(@progress_report) if @progress_report.update_attributes!(permitted_attributes(@progress_report))
   end
 
   # DELETE /progress_reports/1
@@ -51,5 +51,9 @@ class ProgressReportsController < ApplicationController
 
   def base_object
     ProgressReport.with_versions
+  end
+
+  def serialize(target, serializer: ProgressReportSerializer)
+    super
   end
 end

--- a/app/controllers/recommendation_categories_controller.rb
+++ b/app/controllers/recommendation_categories_controller.rb
@@ -3,7 +3,7 @@ class RecommendationCategoriesController < ApplicationController
 
   # GET /recommendation_categories
   def index
-    @recommendation_categories = policy_scope(RecommendationCategory).order(created_at: :desc).page(params[:page])
+    @recommendation_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @recommendation_categories
 
     render json: @recommendation_categories
@@ -42,7 +42,11 @@ class RecommendationCategoriesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_recommendation_category
-    @recommendation_category = policy_scope(RecommendationCategory).find(params[:id])
+    @recommendation_category = policy_scope(base_object).find(params[:id])
     authorize @recommendation_category
+  end
+
+  def base_object
+    RecommendationCategory
   end
 end

--- a/app/controllers/recommendation_categories_controller.rb
+++ b/app/controllers/recommendation_categories_controller.rb
@@ -6,12 +6,12 @@ class RecommendationCategoriesController < ApplicationController
     @recommendation_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @recommendation_categories
 
-    render json: @recommendation_categories
+    render json: serialize(@recommendation_categories)
   end
 
   # GET /recommendation_categories/1
   def show
-    render json: @recommendation_category
+    render json: serialize(@recommendation_category)
   end
 
   # POST /recommendation_categories
@@ -21,7 +21,7 @@ class RecommendationCategoriesController < ApplicationController
     authorize @recommendation_category
 
     if @recommendation_category.save
-      render json: @recommendation_category, status: :created, location: @recommendation_category
+      render json: serialize(@recommendation_category), status: :created, location: @recommendation_category
     else
       render json: @recommendation_category.errors, status: :unprocessable_entity
     end
@@ -29,8 +29,9 @@ class RecommendationCategoriesController < ApplicationController
 
   # PATCH/PUT /recommendation_categories/1
   def update
-    render json: @recommendation_category if @recommendation_category
-                                             .update_attributes!(permitted_attributes(@recommendation_category))
+    if @recommendation_category.update_attributes!(permitted_attributes(@recommendation_category))
+      render json: serialize(@recommendation_category)
+    end
   end
 
   # DELETE /recommendation_categories/1
@@ -48,5 +49,9 @@ class RecommendationCategoriesController < ApplicationController
 
   def base_object
     RecommendationCategory
+  end
+
+  def serialize(target, serializer: RecommendationCategorySerializer)
+    super
   end
 end

--- a/app/controllers/recommendation_measures_controller.rb
+++ b/app/controllers/recommendation_measures_controller.rb
@@ -3,7 +3,7 @@ class RecommendationMeasuresController < ApplicationController
 
   # GET /recommendation_measures
   def index
-    @recommendation_measures = policy_scope(RecommendationMeasure).order(created_at: :desc).page(params[:page])
+    @recommendation_measures = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @recommendation_measures
 
     render json: @recommendation_measures
@@ -42,7 +42,11 @@ class RecommendationMeasuresController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_recommendation_measure
-    @recommendation_measure = policy_scope(RecommendationMeasure).find(params[:id])
+    @recommendation_measure = policy_scope(base_object).find(params[:id])
     authorize @recommendation_measure
+  end
+
+  def base_object
+    RecommendationMeasure
   end
 end

--- a/app/controllers/recommendation_measures_controller.rb
+++ b/app/controllers/recommendation_measures_controller.rb
@@ -6,12 +6,12 @@ class RecommendationMeasuresController < ApplicationController
     @recommendation_measures = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @recommendation_measures
 
-    render json: @recommendation_measures
+    render json: serialize(@recommendation_measures)
   end
 
   # GET /recommendation_measures/1
   def show
-    render json: @recommendation_measure
+    render json: serialize(@recommendation_measure)
   end
 
   # POST /recommendation_measures
@@ -21,7 +21,7 @@ class RecommendationMeasuresController < ApplicationController
     authorize @recommendation_measure
 
     if @recommendation_measure.save
-      render json: @recommendation_measure, status: :created, location: @recommendation_measure
+      render json: serialize(@recommendation_measure), status: :created, location: @recommendation_measure
     else
       render json: @recommendation_measure.errors, status: :unprocessable_entity
     end
@@ -29,8 +29,9 @@ class RecommendationMeasuresController < ApplicationController
 
   # PATCH/PUT /recommendation_measures/1
   def update
-    render json: @recommendation_measure if @recommendation_measure
-                                            .update_attributes!(permitted_attributes(@recommendation_measure))
+    if @recommendation_measure.update_attributes!(permitted_attributes(@recommendation_measure))
+      render json: serialize(@recommendation_measure)
+    end
   end
 
   # DELETE /recommendation_measures/1
@@ -48,5 +49,9 @@ class RecommendationMeasuresController < ApplicationController
 
   def base_object
     RecommendationMeasure
+  end
+
+  def serialize(target, serializer: RecommendationMeasureSerializer)
+    super
   end
 end

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -7,12 +7,12 @@ class RecommendationsController < ApplicationController
     @recommendations = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @recommendations
 
-    render json: @recommendations
+    render json: serialize(@recommendations)
   end
 
   # GET /recommendations/1
   def show
-    render json: @recommendation
+    render json: serialize(@recommendation)
   end
 
   # POST /recommendations
@@ -22,7 +22,7 @@ class RecommendationsController < ApplicationController
     authorize @recommendation
 
     if @recommendation.save
-      render json: @recommendation, status: :created, location: @recommendation
+      render json: serialize(@recommendation), status: :created, location: @recommendation
     else
       render json: @recommendation.errors, status: :unprocessable_entity
     end
@@ -33,7 +33,7 @@ class RecommendationsController < ApplicationController
     if params[:recommendation][:updated_at] && DateTime.parse(params[:recommendation][:updated_at]).to_i != @recommendation.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: @recommendation if @recommendation.update_attributes!(permitted_attributes(@recommendation))
+    render json: serialize(@recommendation) if @recommendation.update_attributes!(permitted_attributes(@recommendation))
   end
 
   # DELETE /recommendations/1
@@ -57,5 +57,9 @@ class RecommendationsController < ApplicationController
   def set_and_authorize_recommendation
     @recommendation = policy_scope(base_object).find(params[:id])
     authorize @recommendation
+  end
+
+  def serialize(target, serializer: RecommendationSerializer)
+    super
   end
 end

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -44,10 +44,13 @@ class RecommendationsController < ApplicationController
   private
 
   def base_object
-    return Category.find(params[:category_id]).recommendations if params[:category_id]
-    return Measure.find(params[:measure_id]).recommendations if params[:measure_id]
-
-    Recommendation
+    if params[:category_id]
+      Category.find(params[:category_id]).recommendations
+    elsif params[:measure_id]
+      Measure.find(params[:measure_id]).recommendations
+    else
+      Recommendation
+    end.with_versions
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -6,12 +6,12 @@ class RolesController < ApplicationController
     @roles = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @roles
 
-    render json: @roles
+    render json: serialize(@roles)
   end
 
   # GET /roles/1
   def show
-    render json: @role
+    render json: serialize(@role)
   end
 
   # POST /roles
@@ -21,7 +21,7 @@ class RolesController < ApplicationController
     authorize @role
 
     if @role.save
-      render json: @role, status: :created, location: @role
+      render json: serialize(@role), status: :created, location: @role
     else
       render json: @role.errors, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class RolesController < ApplicationController
 
   # PATCH/PUT /roles/1
   def update
-    render json: @role if @role.update_attributes!(permitted_attributes(@role))
+    render json: serialize(@role) if @role.update_attributes!(permitted_attributes(@role))
   end
 
   # DELETE /roles/1
@@ -47,5 +47,9 @@ class RolesController < ApplicationController
   def set_and_authorize_role
     @role = policy_scope(base_object).find(params[:id])
     authorize @role
+  end
+
+  def serialize(target, serializer: RoleSerializer)
+    super
   end
 end

--- a/app/controllers/sdgtarget_categories_controller.rb
+++ b/app/controllers/sdgtarget_categories_controller.rb
@@ -6,12 +6,12 @@ class SdgtargetCategoriesController < ApplicationController
     @sdgtarget_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @sdgtarget_categories
 
-    render json: @sdgtarget_categories
+    render json: serialize(@sdgtarget_categories)
   end
 
   # GET /sdgtarget_categories/1
   def show
-    render json: @sdgtarget_category
+    render json: serialize(@sdgtarget_category)
   end
 
   # POST /sdgtarget_categories
@@ -21,7 +21,7 @@ class SdgtargetCategoriesController < ApplicationController
     authorize @sdgtarget_category
 
     if @sdgtarget_category.save
-      render json: @sdgtarget_category, status: :created, location: @sdgtarget_category
+      render json: serialize(@sdgtarget_category), status: :created, location: @sdgtarget_category
     else
       render json: @sdgtarget_category.errors, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class SdgtargetCategoriesController < ApplicationController
 
   # PATCH/PUT /sdgtarget_categories/1
   def update
-    render json: @sdgtarget_category if @sdgtarget_category.update_attributes!(permitted_attributes(@sdgtarget_category))
+    render json: serialize(@sdgtarget_category) if @sdgtarget_category.update_attributes!(permitted_attributes(@sdgtarget_category))
   end
 
   # DELETE /sdgtarget_categories/1
@@ -47,5 +47,9 @@ class SdgtargetCategoriesController < ApplicationController
 
   def base_object
     SdgtargetCategory
+  end
+
+  def serialize(target, serializer: SdgtargetCategorySerializer)
+    super
   end
 end

--- a/app/controllers/sdgtarget_categories_controller.rb
+++ b/app/controllers/sdgtarget_categories_controller.rb
@@ -3,7 +3,7 @@ class SdgtargetCategoriesController < ApplicationController
 
   # GET /sdgtarget_categories
   def index
-    @sdgtarget_categories = policy_scope(SdgtargetCategory).order(created_at: :desc).page(params[:page])
+    @sdgtarget_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @sdgtarget_categories
 
     render json: @sdgtarget_categories
@@ -41,7 +41,11 @@ class SdgtargetCategoriesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_sdgtarget_category
-    @sdgtarget_category = policy_scope(SdgtargetCategory).find(params[:id])
+    @sdgtarget_category = policy_scope(base_object).find(params[:id])
     authorize @sdgtarget_category
+  end
+
+  def base_object
+    SdgtargetCategory
   end
 end

--- a/app/controllers/sdgtarget_indicators_controller.rb
+++ b/app/controllers/sdgtarget_indicators_controller.rb
@@ -3,7 +3,7 @@ class SdgtargetIndicatorsController < ApplicationController
 
   # GET /sdgtarget_categories
   def index
-    @sdgtarget_categories = policy_scope(SdgtargetIndicator).order(created_at: :desc).page(params[:page])
+    @sdgtarget_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @sdgtarget_categories
 
     render json: @sdgtarget_categories
@@ -41,7 +41,11 @@ class SdgtargetIndicatorsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_sdgtarget_indicator
-    @sdgtarget_indicator = policy_scope(SdgtargetIndicator).find(params[:id])
+    @sdgtarget_indicator = policy_scope(base_object).find(params[:id])
     authorize @sdgtarget_indicator
+  end
+
+  def base_object
+    SdgtargetIndicator
   end
 end

--- a/app/controllers/sdgtarget_indicators_controller.rb
+++ b/app/controllers/sdgtarget_indicators_controller.rb
@@ -6,12 +6,12 @@ class SdgtargetIndicatorsController < ApplicationController
     @sdgtarget_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @sdgtarget_categories
 
-    render json: @sdgtarget_categories
+    render json: serialize(@sdgtarget_categories)
   end
 
   # GET /sdgtarget_categories/1
   def show
-    render json: @sdgtarget_indicator
+    render json: serialize(@sdgtarget_indicator)
   end
 
   # POST /sdgtarget_categories
@@ -21,7 +21,7 @@ class SdgtargetIndicatorsController < ApplicationController
     authorize @sdgtarget_indicator
 
     if @sdgtarget_indicator.save
-      render json: @sdgtarget_indicator, status: :created, location: @sdgtarget_indicator
+      render json: serialize(@sdgtarget_indicator), status: :created, location: @sdgtarget_indicator
     else
       render json: @sdgtarget_indicator.errors, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class SdgtargetIndicatorsController < ApplicationController
 
   # PATCH/PUT /sdgtarget_categories/1
   def update
-    render json: @sdgtarget_indicator if @sdgtarget_indicator.update_attributes!(permitted_attributes(@sdgtarget_indicator))
+    render json: serialize(@sdgtarget_indicator) if @sdgtarget_indicator.update_attributes!(permitted_attributes(@sdgtarget_indicator))
   end
 
   # DELETE /sdgtarget_categories/1
@@ -47,5 +47,9 @@ class SdgtargetIndicatorsController < ApplicationController
 
   def base_object
     SdgtargetIndicator
+  end
+
+  def serialize(target, serializer: SdgtargetIndicatorSerializer)
+    super
   end
 end

--- a/app/controllers/sdgtarget_measures_controller.rb
+++ b/app/controllers/sdgtarget_measures_controller.rb
@@ -6,12 +6,12 @@ class SdgtargetMeasuresController < ApplicationController
     @sdgtarget_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @sdgtarget_categories
 
-    render json: @sdgtarget_categories
+    render json: serialize(@sdgtarget_categories)
   end
 
   # GET /sdgtarget_categories/1
   def show
-    render json: @sdgtarget_measure
+    render json: serialize(@sdgtarget_measure)
   end
 
   # POST /sdgtarget_categories
@@ -21,7 +21,7 @@ class SdgtargetMeasuresController < ApplicationController
     authorize @sdgtarget_measure
 
     if @sdgtarget_measure.save
-      render json: @sdgtarget_measure, status: :created, location: @sdgtarget_measure
+      render json: serialize(@sdgtarget_measure), status: :created, location: @sdgtarget_measure
     else
       render json: @sdgtarget_measure.errors, status: :unprocessable_entity
     end
@@ -29,7 +29,7 @@ class SdgtargetMeasuresController < ApplicationController
 
   # PATCH/PUT /sdgtarget_categories/1
   def update
-    render json: @sdgtarget_measure if @sdgtarget_measure.update_attributes!(permitted_attributes(@sdgtarget_measure))
+    render json: serialize(@sdgtarget_measure) if @sdgtarget_measure.update_attributes!(permitted_attributes(@sdgtarget_measure))
   end
 
   # DELETE /sdgtarget_categories/1
@@ -47,5 +47,9 @@ class SdgtargetMeasuresController < ApplicationController
 
   def base_object
     SdgtargetMeasure
+  end
+
+  def serialize(target, serializer: SdgtargetMeasureSerializer)
+    super
   end
 end

--- a/app/controllers/sdgtarget_measures_controller.rb
+++ b/app/controllers/sdgtarget_measures_controller.rb
@@ -3,7 +3,7 @@ class SdgtargetMeasuresController < ApplicationController
 
   # GET /sdgtarget_categories
   def index
-    @sdgtarget_categories = policy_scope(SdgtargetMeasure).order(created_at: :desc).page(params[:page])
+    @sdgtarget_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @sdgtarget_categories
 
     render json: @sdgtarget_categories
@@ -41,7 +41,11 @@ class SdgtargetMeasuresController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_sdgtarget_measure
-    @sdgtarget_measure = policy_scope(SdgtargetMeasure).find(params[:id])
+    @sdgtarget_measure = policy_scope(base_object).find(params[:id])
     authorize @sdgtarget_measure
+  end
+
+  def base_object
+    SdgtargetMeasure
   end
 end

--- a/app/controllers/sdgtarget_recommendations_controller.rb
+++ b/app/controllers/sdgtarget_recommendations_controller.rb
@@ -3,7 +3,7 @@ class SdgtargetRecommendationsController < ApplicationController
 
   # GET /sdgtarget_categories
   def index
-    @sdgtarget_categories = policy_scope(SdgtargetRecommendation).order(created_at: :desc).page(params[:page])
+    @sdgtarget_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @sdgtarget_categories
 
     render json: @sdgtarget_categories
@@ -41,7 +41,11 @@ class SdgtargetRecommendationsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_sdgtarget_recommendation
-    @sdgtarget_recommendation = policy_scope(SdgtargetRecommendation).find(params[:id])
+    @sdgtarget_recommendation = policy_scope(base_object).find(params[:id])
     authorize @sdgtarget_recommendation
+  end
+
+  def base_object
+    SdgtargetRecommendation
   end
 end

--- a/app/controllers/sdgtarget_recommendations_controller.rb
+++ b/app/controllers/sdgtarget_recommendations_controller.rb
@@ -6,12 +6,12 @@ class SdgtargetRecommendationsController < ApplicationController
     @sdgtarget_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @sdgtarget_categories
 
-    render json: @sdgtarget_categories
+    render json: serialize(@sdgtarget_categories, serializer: SdgtargetCategorySerializer)
   end
 
   # GET /sdgtarget_categories/1
   def show
-    render json: @sdgtarget_recommendation
+    render json: serialize(@sdgtarget_recommendation)
   end
 
   # POST /sdgtarget_categories
@@ -47,5 +47,9 @@ class SdgtargetRecommendationsController < ApplicationController
 
   def base_object
     SdgtargetRecommendation
+  end
+
+  def serialize(target, serializer: SdgtargetRecommendationSerializer)
+    super
   end
 end

--- a/app/controllers/sdgtargets_controller.rb
+++ b/app/controllers/sdgtargets_controller.rb
@@ -44,11 +44,15 @@ class SdgtargetsController < ApplicationController
   private
 
   def base_object
-    return Category.find(params[:category_id]).sdgtargets if params[:category_id]
-    return Recommendation.find(params[:recommendation_id]).sdgtargets if params[:recommendation_id]
-    return Indicator.find(params[:indicator_id]).sdgtargets if params[:indicator_id]
-
-    Sdgtarget
+    if params[:category_id]
+      Category.find(params[:category_id]).measures
+    elsif params[:recommendation_id]
+      Recommendation.find(params[:recommendation_id]).measures
+    elsif params[:indicator_id]
+      Indicator.find(params[:indicator_id]).measures
+    else
+      Sdgtarget
+    end.with_versions
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/sdgtargets_controller.rb
+++ b/app/controllers/sdgtargets_controller.rb
@@ -7,12 +7,12 @@ class SdgtargetsController < ApplicationController
     @sdgtargets = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @sdgtargets
 
-    render json: @sdgtargets
+    render json: serialize(@sdgtargets)
   end
 
   # GET /sdgtargets/1
   def show
-    render json: @sdgtarget
+    render json: serialize(@sdgtarget)
   end
 
   # POST /sdgtargets
@@ -22,7 +22,7 @@ class SdgtargetsController < ApplicationController
     authorize @sdgtarget
 
     if @sdgtarget.save
-      render json: @sdgtarget, status: :created, location: @sdgtarget
+      render json: serialize(@sdgtarget), status: :created, location: @sdgtarget
     else
       render json: @sdgtarget.errors, status: :unprocessable_entity
     end
@@ -33,7 +33,7 @@ class SdgtargetsController < ApplicationController
     if params[:sdgtarget][:updated_at] && DateTime.parse(params[:sdgtarget][:updated_at]).to_i != @sdgtarget.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: @sdgtarget if @sdgtarget.update_attributes!(permitted_attributes(@sdgtarget))
+    render json: serialize(@sdgtarget) if @sdgtarget.update_attributes!(permitted_attributes(@sdgtarget))
   end
 
   # DELETE /sdgtargets/1
@@ -53,6 +53,10 @@ class SdgtargetsController < ApplicationController
     else
       Sdgtarget
     end.with_versions
+  end
+
+  def serialize(target, serializer: SdgtargetSerializer)
+    super
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/taxonomies_controller.rb
+++ b/app/controllers/taxonomies_controller.rb
@@ -6,12 +6,12 @@ class TaxonomiesController < ApplicationController
     @taxonomies = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @taxonomies
 
-    render json: @taxonomies
+    render json: serialize(@taxonomies)
   end
 
   # GET /taxonomies/1
   def show
-    render json: @taxonomy
+    render json: serialize(@taxonomy)
   end
 
   # POST /taxonomies
@@ -21,7 +21,7 @@ class TaxonomiesController < ApplicationController
     authorize @taxonomy
 
     if @taxonomy.save
-      render json: @taxonomy, status: :created, location: @taxonomy
+      render json: serialize(@taxonomy), status: :created, location: @taxonomy
     else
       render json: @taxonomy.errors, status: :unprocessable_entity
     end
@@ -29,7 +29,9 @@ class TaxonomiesController < ApplicationController
 
   # PATCH/PUT /taxonomies/1
   def update
-    render json: @taxonomy if @taxonomy.update_attributes!(permitted_attributes(@taxonomy))
+    if @taxonomy.update_attributes!(permitted_attributes(@taxonomy))
+      render json: serialize(@taxonomy)
+    end
   end
 
   # DELETE /taxonomies/1
@@ -47,5 +49,9 @@ class TaxonomiesController < ApplicationController
 
   def base_object
     Taxonomy.with_versions
+  end
+
+  def serialize(target, serializer: TaxonomySerializer)
+    super
   end
 end

--- a/app/controllers/taxonomies_controller.rb
+++ b/app/controllers/taxonomies_controller.rb
@@ -3,7 +3,7 @@ class TaxonomiesController < ApplicationController
 
   # GET /taxonomies
   def index
-    @taxonomies = policy_scope(Taxonomy).order(created_at: :desc).page(params[:page])
+    @taxonomies = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @taxonomies
 
     render json: @taxonomies
@@ -41,7 +41,11 @@ class TaxonomiesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_taxonomy
-    @taxonomy = policy_scope(Taxonomy).find(params[:id])
+    @taxonomy = policy_scope(base_object).find(params[:id])
     authorize @taxonomy
+  end
+
+  def base_object
+    Taxonomy.with_versions
   end
 end

--- a/app/controllers/user_categories_controller.rb
+++ b/app/controllers/user_categories_controller.rb
@@ -6,12 +6,12 @@ class UserCategoriesController < ApplicationController
     @user_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @user_categories
 
-    render json: @user_categories
+    render json: serialize(@user_categories)
   end
 
   # GET /user_categories/1
   def show
-    render json: @user_category
+    render json: serialize(@user_category)
   end
 
   # POST /user_categories
@@ -21,7 +21,7 @@ class UserCategoriesController < ApplicationController
     authorize @user_category
 
     if @user_category.save
-      render json: @user_category, status: :created, location: @user_category
+      render json: serialize(@user_category), status: :created, location: @user_category
     else
       render json: @user_category.errors, status: :unprocessable_entity
     end
@@ -29,8 +29,9 @@ class UserCategoriesController < ApplicationController
 
   # PATCH/PUT /user_categories/1
   def update
-    render json: @user_category if @user_category
-                                             .update_attributes!(permitted_attributes(@user_category))
+    if @user_category.update_attributes!(permitted_attributes(@user_category))
+      render json: serialize(@user_category)
+    end
   end
 
   # DELETE /user_categories/1
@@ -48,5 +49,9 @@ class UserCategoriesController < ApplicationController
 
   def base_object
     UserCategory
+  end
+
+  def serialize(target, serializer: UserCategorySerializer)
+    super
   end
 end

--- a/app/controllers/user_categories_controller.rb
+++ b/app/controllers/user_categories_controller.rb
@@ -3,7 +3,7 @@ class UserCategoriesController < ApplicationController
 
   # GET /user_categories
   def index
-    @user_categories = policy_scope(UserCategory).order(created_at: :desc).page(params[:page])
+    @user_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @user_categories
 
     render json: @user_categories
@@ -42,7 +42,11 @@ class UserCategoriesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_user_category
-    @user_category = policy_scope(UserCategory).find(params[:id])
+    @user_category = policy_scope(base_object).find(params[:id])
     authorize @user_category
+  end
+
+  def base_object
+    UserCategory
   end
 end

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -29,8 +29,9 @@ class UserRolesController < ApplicationController
 
   # PATCH/PUT /user_roles/1
   def update
-    render json: @user_role if @user_role
-                                            .update_attributes!(permitted_attributes(@user_role))
+    if @user_role.update_attributes!(permitted_attributes(@user_role))
+      render json: @user_role
+    end
   end
 
   # DELETE /user_roles/1

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -3,7 +3,7 @@ class UserRolesController < ApplicationController
 
   # GET /user_roles
   def index
-    @user_roles = policy_scope(UserRole).order(created_at: :desc).page(params[:page])
+    @user_roles = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @user_roles
 
     render json: @user_roles
@@ -43,7 +43,11 @@ class UserRolesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_user_role
-    @user_role = policy_scope(UserRole).find(params[:id])
+    @user_role = policy_scope(base_object).find(params[:id])
     authorize @user_role
+  end
+
+  def base_object
+    UserRole
   end
 end

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -6,12 +6,12 @@ class UserRolesController < ApplicationController
     @user_roles = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @user_roles
 
-    render json: @user_roles
+    render json: serialize(@user_roles)
   end
 
   # GET /@user_roles/1
   def show
-    render json: @user_role
+    render json: serialize(@user_role)
   end
 
   # POST /user_roles
@@ -21,7 +21,7 @@ class UserRolesController < ApplicationController
     authorize @user_role
 
     if @user_role.save
-      render json: @user_role, status: :created, location: @user_role
+      render json: serialize(@user_role), status: :created, location: @user_role
     else
       render json: @user_role.errors, status: :unprocessable_entity
     end
@@ -30,7 +30,7 @@ class UserRolesController < ApplicationController
   # PATCH/PUT /user_roles/1
   def update
     if @user_role.update_attributes!(permitted_attributes(@user_role))
-      render json: @user_role
+      render json: serialize(@user_role)
     end
   end
 
@@ -49,5 +49,9 @@ class UserRolesController < ApplicationController
 
   def base_object
     UserRole
+  end
+
+  def serialize(target, serializer: UserRoleSerializer)
+    super
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,12 +8,12 @@ class UsersController < ApplicationController
     @users = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @users
 
-    render json: @users
+    render json: serialize(@users)
   end
 
   # GET /users/1
   def show
-    render json: @user
+    render json: serialize(@user)
   end
 
   # POST /users
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
     authorize @user
 
     if @user.save
-      render json: @user, status: :created, location: @user
+      render json: serialize(@user), status: :created, location: @user
     else
       render json: @user.errors, status: :unprocessable_entity
     end
@@ -31,7 +31,7 @@ class UsersController < ApplicationController
 
   # PATCH/PUT /users/1
   def update
-    render json: @user if @user.update_attributes!(permitted_attributes(@user))
+    render json: serialize(@user) if @user.update_attributes!(permitted_attributes(@user))
   end
 
   # DELETE /users/1
@@ -43,6 +43,10 @@ class UsersController < ApplicationController
 
   def base_object
     User
+  end
+
+  def serialize(target, serializer: UserSerializer)
+    super
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,13 +3,11 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   def last_modified_user_id
-    return nil unless respond_to? :versions
-    return nil unless versions.last
-    versions.last.whodunnit
+    self[:last_modified_user_id] || calculate_last_modified_user_id
   end
 
-  def last_modified_user
-    return nil unless last_modified_user_id
-    User.find last_modified_user_id
+  protected def calculate_last_modified_user_id
+    return nil unless respond_to?(:versions) && versions.last
+    versions.last.whodunnit
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,4 @@
-class Category < ApplicationRecord
-  has_paper_trail
-
+class Category < VersionedRecord
   belongs_to :taxonomy
   belongs_to :manager, class_name: User, foreign_key: :manager_id, optional: true, inverse_of: :categories
   has_many :recommendation_categories, inverse_of: :category, dependent: :destroy
@@ -15,8 +13,6 @@ class Category < ApplicationRecord
   has_many :due_dates,-> { uniq }, through: :indicators
 
   delegate :name, :email, to: :manager, prefix: true, allow_nil: true
-
-  default_scope { includes(:versions) }
 
   validates :title, presence: true
 

--- a/app/models/due_date.rb
+++ b/app/models/due_date.rb
@@ -1,6 +1,4 @@
-class DueDate < ApplicationRecord
-  has_paper_trail
-
+class DueDate < VersionedRecord
   belongs_to :indicator
   has_one :manager, through: :indicator
   has_many :progress_reports
@@ -17,8 +15,6 @@ class DueDate < ApplicationRecord
   scope :future_with_no_progress_reports, -> { future.no_progress_reports }
   scope :are_due, -> { no_progress_reports.where('due_date >= ? AND due_date <= ?', Date.today, Date.today + DUE_NUMBER_OF_DAYS.days) }
   scope :are_overdue, -> { no_progress_reports.where('due_date < ?', Date.today) }
-
-  default_scope { includes(:versions) }
 
   DUE_NUMBER_OF_DAYS = 30.freeze
 

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -1,6 +1,4 @@
-class Indicator < ApplicationRecord
-  has_paper_trail
-
+class Indicator < VersionedRecord
   validates :title, presence: true
   validates :end_date, presence: true, if: :repeat?
   validates :frequency_months, presence: true, if: :repeat?
@@ -20,8 +18,6 @@ class Indicator < ApplicationRecord
   belongs_to :manager, class_name: User, foreign_key: :manager_id, required: false
 
   accepts_nested_attributes_for :measure_indicators
-
-  default_scope { includes(:versions) }
 
   private
 

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
-class Measure < ApplicationRecord
-  has_paper_trail
-
+class Measure < VersionedRecord
   has_many :recommendation_measures, inverse_of: :measure, dependent: :destroy
   has_many :sdgtarget_measures, inverse_of: :measure, dependent: :destroy
   has_many :measure_categories, inverse_of: :measure, dependent: :destroy
@@ -17,6 +15,4 @@ class Measure < ApplicationRecord
   accepts_nested_attributes_for :measure_categories
 
   validates :title, presence: true
-
-  default_scope { includes(:versions) }
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,7 +1,3 @@
-class Page < ApplicationRecord
-  has_paper_trail
-
+class Page < VersionedRecord
   validates :title, presence: true
-
-  default_scope { includes(:versions) }
 end

--- a/app/models/progress_report.rb
+++ b/app/models/progress_report.rb
@@ -1,6 +1,4 @@
-class ProgressReport < ApplicationRecord
-  has_paper_trail
-
+class ProgressReport < VersionedRecord
   belongs_to :indicator
   belongs_to :due_date, required: false
   has_many :measures, through: :indicator
@@ -10,6 +8,4 @@ class ProgressReport < ApplicationRecord
 
   validates :title, presence: true
   validates :indicator_id, presence: true
-
-  default_scope { includes(:versions) }
 end

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
-class Recommendation < ApplicationRecord
-  has_paper_trail
-
+class Recommendation < VersionedRecord
   has_many :recommendation_measures, inverse_of: :recommendation, dependent: :destroy
   has_many :recommendation_categories, inverse_of: :recommendation, dependent: :destroy
   has_many :sdgtarget_recommendations, inverse_of: :recommendation, dependent: :destroy
@@ -15,6 +13,4 @@ class Recommendation < ApplicationRecord
 
   validates :title, presence: true
   validates :reference, presence: true
-
-  default_scope { includes(:versions) }
 end

--- a/app/models/sdgtarget.rb
+++ b/app/models/sdgtarget.rb
@@ -1,6 +1,4 @@
-class Sdgtarget < ApplicationRecord
-  has_paper_trail
-
+class Sdgtarget < VersionedRecord
   has_many :sdgtarget_categories, inverse_of: :sdgtarget, dependent: :destroy
   has_many :sdgtarget_indicators, inverse_of: :sdgtarget, dependent: :destroy
   has_many :sdgtarget_recommendations, inverse_of: :sdgtarget, dependent: :destroy
@@ -8,6 +6,4 @@ class Sdgtarget < ApplicationRecord
 
   validates :reference, presence: true
   validates :title, presence: true
-
-  default_scope { includes(:versions) }
 end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,6 +1,4 @@
-class Taxonomy < ApplicationRecord
-  has_paper_trail
-
+class Taxonomy < VersionedRecord
   has_many :categories
 
   validates :title, presence: true
@@ -8,6 +6,4 @@ class Taxonomy < ApplicationRecord
   validates :allow_multiple, inclusion: [true, false]
   validates :tags_recommendations, inclusion: [true, false]
   validates :tags_measures, inclusion: [true, false]
-
-  default_scope { includes(:versions) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,16 @@ class User < ApplicationRecord
   include DeviseTokenAuth::Concerns::User
   has_paper_trail ignore: [:tokens, :updated_at]
 
+  def last_modified_user_id
+    return nil unless respond_to?(:versions) && versions.last
+    versions.last.whodunnit
+  end
+
+  def last_modified_user
+    return nil unless last_modified_user_id
+    User.find last_modified_user_id
+  end
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -1,6 +1,4 @@
-class UserRole < ApplicationRecord
-  has_paper_trail
-
+class UserRole < VersionedRecord
   belongs_to :user
   belongs_to :role
 

--- a/app/models/versioned_record.rb
+++ b/app/models/versioned_record.rb
@@ -1,0 +1,19 @@
+require_relative 'application_record'
+
+class VersionedRecord < ApplicationRecord
+  self.abstract_class = true
+
+  has_paper_trail
+
+  def last_modified_user
+    return nil unless last_modified_user_id
+    @last_modified_user ||= User.find(last_modified_user_id)
+  end
+
+  scope :with_versions, -> do
+    left_outer_joins(:versions).select(
+      "#{quoted_table_name}.*",
+      "#{::PaperTrail::Version.quoted_table_name}.whodunnit AS last_modified_user_id"
+    )
+  end
+end

--- a/app/models/versioned_record.rb
+++ b/app/models/versioned_record.rb
@@ -11,9 +11,13 @@ class VersionedRecord < ApplicationRecord
   end
 
   scope :with_versions, -> do
-    left_outer_joins(:versions).select(
-      "#{quoted_table_name}.*",
-      "#{::PaperTrail::Version.quoted_table_name}.whodunnit AS last_modified_user_id"
+    select(
+      "#{quoted_table_name}.*," \
+      "(SELECT whodunnit FROM #{::PaperTrail::Version.quoted_table_name} " \
+      "WHERE #{::PaperTrail::Version.quoted_table_name}.item_type = '#{self.base_class.name}' " \
+      "AND #{::PaperTrail::Version.quoted_table_name}.item_id = #{quoted_table_name}.id " \
+      "ORDER BY #{::PaperTrail::Version.quoted_table_name}.created_at DESC " \
+      "LIMIT 1) last_modified_user_id"
     )
   end
 end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,3 +1,7 @@
-class CategorySerializer < ApplicationSerializer
+class CategorySerializer
+  include FastApplicationSerializer
+
   attributes :title, :short_title, :description, :url, :draft, :reference, :taxonomy_id, :manager_id, :user_only
+
+  set_type :categories
 end

--- a/app/serializers/due_date_serializer.rb
+++ b/app/serializers/due_date_serializer.rb
@@ -1,3 +1,7 @@
-class DueDateSerializer < ApplicationSerializer
+class DueDateSerializer
+  include FastApplicationSerializer
+
   attributes :due_date, :draft, :indicator_id, :due, :overdue, :has_progress_report
+
+  set_type :due_dates
 end

--- a/app/serializers/measure_category_serializer.rb
+++ b/app/serializers/measure_category_serializer.rb
@@ -1,3 +1,7 @@
-class MeasureCategorySerializer < ApplicationSerializer
+class MeasureCategorySerializer
+  include FastApplicationSerializer
+
   attributes :measure_id, :category_id
+
+  set_type :measure_categories
 end

--- a/app/serializers/measure_indicator_serializer.rb
+++ b/app/serializers/measure_indicator_serializer.rb
@@ -1,3 +1,7 @@
-class MeasureIndicatorSerializer < ApplicationSerializer
+class MeasureIndicatorSerializer
+  include FastApplicationSerializer
+
   attributes :measure_id, :indicator_id
+
+  set_type :measure_indicators
 end

--- a/app/serializers/measure_serializer.rb
+++ b/app/serializers/measure_serializer.rb
@@ -1,3 +1,7 @@
-class MeasureSerializer < ApplicationSerializer
+class MeasureSerializer
+  include FastApplicationSerializer
+
   attributes :title, :description, :target_date, :draft, :outcome, :indicator_summary, :target_date_comment
+
+  set_type :measures
 end

--- a/app/serializers/page_serializer.rb
+++ b/app/serializers/page_serializer.rb
@@ -1,3 +1,7 @@
-class PageSerializer < ApplicationSerializer
+class PageSerializer
+  include FastApplicationSerializer
+
   attributes :title, :content, :menu_title, :order, :draft
+
+  set_type :pages
 end

--- a/app/serializers/progress_report_serializer.rb
+++ b/app/serializers/progress_report_serializer.rb
@@ -1,3 +1,7 @@
-class ProgressReportSerializer < ApplicationSerializer
+class ProgressReportSerializer
+  include FastApplicationSerializer
+
   attributes :indicator_id, :due_date_id, :title, :description, :document_url, :document_public, :draft
+
+  set_type :progress_reports
 end

--- a/app/serializers/recommendation_category_serializer.rb
+++ b/app/serializers/recommendation_category_serializer.rb
@@ -1,3 +1,7 @@
-class RecommendationCategorySerializer < ApplicationSerializer
+class RecommendationCategorySerializer
+  include FastApplicationSerializer
+
   attributes :recommendation_id, :category_id
+
+  set_type :recommendation_categories
 end

--- a/app/serializers/recommendation_measure_serializer.rb
+++ b/app/serializers/recommendation_measure_serializer.rb
@@ -1,3 +1,7 @@
-class RecommendationMeasureSerializer < ApplicationSerializer
+class RecommendationMeasureSerializer
+  include FastApplicationSerializer
+
   attributes :recommendation_id, :measure_id
+
+  set_type :recommendation_measures
 end

--- a/app/serializers/recommendation_serializer.rb
+++ b/app/serializers/recommendation_serializer.rb
@@ -1,3 +1,7 @@
-class RecommendationSerializer < ApplicationSerializer
+class RecommendationSerializer
+  include FastApplicationSerializer
+
   attributes :title, :accepted, :response, :draft, :reference
+
+  set_type :recommendations
 end

--- a/app/serializers/role_serializer.rb
+++ b/app/serializers/role_serializer.rb
@@ -1,3 +1,7 @@
-class RoleSerializer < ApplicationSerializer
+class RoleSerializer
+  include FastApplicationSerializer
+
   attributes :name, :friendly_name
+
+  set_type :roles
 end

--- a/app/serializers/sdgtarget_category_serializer.rb
+++ b/app/serializers/sdgtarget_category_serializer.rb
@@ -1,3 +1,7 @@
-class SdgtargetCategorySerializer < ApplicationSerializer
+class SdgtargetCategorySerializer
+  include FastApplicationSerializer
+
   attributes :sdgtarget_id, :category_id
+
+  set_type :sdgtarget_categories
 end

--- a/app/serializers/sdgtarget_indicator_serializer.rb
+++ b/app/serializers/sdgtarget_indicator_serializer.rb
@@ -1,3 +1,7 @@
-class SdgtargetIndicatorSerializer < ApplicationSerializer
+class SdgtargetIndicatorSerializer
+  include FastApplicationSerializer
+
   attributes :sdgtarget_id, :indicator_id
+
+  set_type :sdgtarget_indicators
 end

--- a/app/serializers/sdgtarget_measure_serializer.rb
+++ b/app/serializers/sdgtarget_measure_serializer.rb
@@ -1,3 +1,7 @@
-class SdgtargetMeasureSerializer < ApplicationSerializer
+class SdgtargetMeasureSerializer
+  include FastApplicationSerializer
+
   attributes :sdgtarget_id, :measure_id
+
+  set_type :sdgtarget_measures
 end

--- a/app/serializers/sdgtarget_recommendation_serializer.rb
+++ b/app/serializers/sdgtarget_recommendation_serializer.rb
@@ -1,3 +1,7 @@
-class SdgtargetRecommendationSerializer < ApplicationSerializer
+class SdgtargetRecommendationSerializer
+  include FastApplicationSerializer
+
   attributes :sdgtarget_id, :recommendation_id
+
+  set_type :sdgtarget_recommendations
 end

--- a/app/serializers/sdgtarget_serializer.rb
+++ b/app/serializers/sdgtarget_serializer.rb
@@ -1,3 +1,7 @@
-class SdgtargetSerializer < ApplicationSerializer
+class SdgtargetSerializer
+  include FastApplicationSerializer
+
   attributes :title, :description, :reference, :draft
+
+  set_type :sdgtargets
 end

--- a/app/serializers/taxonomy_serializer.rb
+++ b/app/serializers/taxonomy_serializer.rb
@@ -1,3 +1,7 @@
-class TaxonomySerializer < ApplicationSerializer
+class TaxonomySerializer
+  include FastApplicationSerializer
+
   attributes :title, :tags_recommendations, :tags_measures, :tags_users, :allow_multiple, :has_manager, :priority, :tags_sdgtargets, :is_smart, :groups_measures_default, :groups_recommendations_default, :groups_sdgtargets_default
+
+  set_type :taxonomies
 end

--- a/app/serializers/user_category_serializer.rb
+++ b/app/serializers/user_category_serializer.rb
@@ -1,3 +1,7 @@
-class UserCategorySerializer < ApplicationSerializer
+class UserCategorySerializer
+  include FastApplicationSerializer
+
   attributes :user_id, :category_id
+
+  set_type :user_categories
 end

--- a/app/serializers/user_role_serializer.rb
+++ b/app/serializers/user_role_serializer.rb
@@ -1,3 +1,7 @@
-class UserRoleSerializer < ApplicationSerializer
+class UserRoleSerializer
+  include FastApplicationSerializer
+
   attributes :user_id, :role_id
+
+  set_type :user_roles
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,7 @@
-class UserSerializer < ApplicationSerializer
+class UserSerializer
+  include FastApplicationSerializer
+
   attributes :email, :name
+
+  set_type :users
 end

--- a/db/migrate/20180316001126_index_indicators_on_created_at.rb
+++ b/db/migrate/20180316001126_index_indicators_on_created_at.rb
@@ -1,0 +1,5 @@
+class IndexIndicatorsOnCreatedAt < ActiveRecord::Migration[5.0]
+  def change
+    add_index :indicators, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170719235935) do
+ActiveRecord::Schema.define(version: 20180316001126) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20170719235935) do
     t.boolean  "repeat",           default: false
     t.date     "end_date"
     t.string   "reference"
+    t.index ["created_at"], name: "index_indicators_on_created_at", using: :btree
     t.index ["draft"], name: "index_indicators_on_draft", using: :btree
     t.index ["manager_id"], name: "index_indicators_on_manager_id", using: :btree
   end


### PR DESCRIPTION
Following on from #292 I have applied json_fastapi serializers across the entire application.

Additionally, I discovered that a lot of time is spent loading `last_modified_user_id` from the versions association using paper trail.  If we use a subquery to load the last version (according to created_at DESC) when we load the records then it only requires a single query to load the lot. See the [VersionedRecord](https://github.com/impactoss/impactoss-server/compare/versions-performance?expand=1#diff-32bb04c94fe2deb6ca066d263801c828) model for details.

In my experience this has made the application respond to API requests much faster!