### PR TITLE
Ensure latest last_modified_user_id from PUT update

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -32,7 +32,10 @@ class CategoriesController < ApplicationController
     if params[:category][:updated_at] && DateTime.parse(params[:category][:updated_at]).to_i != @category.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: serialize(@category) if @category.update_attributes!(permitted_attributes(@category))
+    if @category.update_attributes!(permitted_attributes(@category))
+      set_and_authorize_category
+      render json: serialize(@category)
+    end
   end
 
   # DELETE /categories/1

--- a/app/controllers/due_dates_controller.rb
+++ b/app/controllers/due_dates_controller.rb
@@ -29,7 +29,10 @@ class DueDatesController < ApplicationController
 
   # PATCH/PUT /due_dates/1
   def update
-    render json: serialize(@due_date) if @due_date.update_attributes!(permitted_attributes(@due_date))
+    if @due_date.update_attributes!(permitted_attributes(@due_date))
+      set_and_authorize_due_date
+      render json: serialize(@due_date)
+    end
   end
 
   # DELETE /due_dates/1

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -3,7 +3,7 @@ class IndicatorsController < ApplicationController
 
   # GET /indicators
   def index
-    @indicators = policy_scope(base_object).with_versions.order(created_at: :desc).page(params[:page])
+    @indicators = policy_scope(base_object).order(created_at: :desc).page(params[:page])
     authorize @indicators
 
     render json: serialize(@indicators)
@@ -33,7 +33,10 @@ class IndicatorsController < ApplicationController
     if params[:indicator][:updated_at] && DateTime.parse(params[:indicator][:updated_at]).to_i != @indicator.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: serialize(@indicator) if @indicator.update_attributes!(permitted_attributes(@indicator))
+    if @indicator.update_attributes!(permitted_attributes(@indicator))
+      set_and_authorize_indicator
+      render json: serialize(@indicator)
+    end
   end
 
   # DELETE /indicators/1
@@ -53,7 +56,7 @@ class IndicatorsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_and_authorize_indicator
-    @indicator = policy_scope(base_object).with_versions.find(params[:id])
+    @indicator = policy_scope(base_object).find(params[:id])
     authorize @indicator
   end
 

--- a/app/controllers/measure_categories_controller.rb
+++ b/app/controllers/measure_categories_controller.rb
@@ -29,7 +29,10 @@ class MeasureCategoriesController < ApplicationController
 
   # PATCH/PUT /measure_categories/1
   def update
-    render json: serialize(@measure_category) if @measure_category.update_attributes!(permitted_attributes(@measure_category))
+    if @measure_category.update_attributes!(permitted_attributes(@measure_category))
+      set_and_authorize_measure_category
+      render json: serialize(@measure_category)
+    end
   end
 
   # DELETE /measure_categories/1

--- a/app/controllers/measure_indicators_controller.rb
+++ b/app/controllers/measure_indicators_controller.rb
@@ -29,7 +29,10 @@ class MeasureIndicatorsController < ApplicationController
 
   # PATCH/PUT /measure_indicators/1
   def update
-    render json: serialize(@measure_indicator) if @measure_indicator.update_attributes!(permitted_attributes(@measure_indicator))
+    if @measure_indicator.update_attributes!(permitted_attributes(@measure_indicator))
+      set_and_authorize_measure_indicator
+      render json: serialize(@measure_indicator)
+    end
   end
 
   # DELETE /measure_indicators/1

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -33,7 +33,10 @@ class MeasuresController < ApplicationController
     if params[:measure][:updated_at] && DateTime.parse(params[:measure][:updated_at]).to_i != @measure.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: serialize(@measure) if @measure.update_attributes!(permitted_attributes(@measure))
+    if @measure.update_attributes!(permitted_attributes(@measure))
+      set_and_authorize_measure
+      render json: serialize(@measure)
+    end
   end
 
   # DELETE /measures/1

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -32,7 +32,10 @@ class PagesController < ApplicationController
     if params[:page][:updated_at] && DateTime.parse(params[:page][:updated_at]).to_i != @page.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: serialize(@page) if @page.update_attributes!(permitted_attributes(@page))
+    if @page.update_attributes!(permitted_attributes(@page))
+      set_and_authorize_page
+      render json: serialize(@page)
+    end
   end
 
   # DELETE /pages/1

--- a/app/controllers/progress_reports_controller.rb
+++ b/app/controllers/progress_reports_controller.rb
@@ -33,7 +33,10 @@ class ProgressReportsController < ApplicationController
     if params[:progress_report][:updated_at] && DateTime.parse(params[:progress_report][:updated_at]).to_i != @progress_report.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: serialize(@progress_report) if @progress_report.update_attributes!(permitted_attributes(@progress_report))
+    if @progress_report.update_attributes!(permitted_attributes(@progress_report))
+      set_and_authorize_progress_report
+      render json: serialize(@progress_report)
+    end
   end
 
   # DELETE /progress_reports/1

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -33,7 +33,10 @@ class RecommendationsController < ApplicationController
     if params[:recommendation][:updated_at] && DateTime.parse(params[:recommendation][:updated_at]).to_i != @recommendation.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: serialize(@recommendation) if @recommendation.update_attributes!(permitted_attributes(@recommendation))
+    if @recommendation.update_attributes!(permitted_attributes(@recommendation))
+      set_and_authorize_recommendation
+      render json: serialize(@recommendation)
+    end
   end
 
   # DELETE /recommendations/1

--- a/app/controllers/sdgtargets_controller.rb
+++ b/app/controllers/sdgtargets_controller.rb
@@ -33,7 +33,10 @@ class SdgtargetsController < ApplicationController
     if params[:sdgtarget][:updated_at] && DateTime.parse(params[:sdgtarget][:updated_at]).to_i != @sdgtarget.updated_at.to_i
       return render json: '{"error":"Record outdated"}', status: :unprocessable_entity
     end
-    render json: serialize(@sdgtarget) if @sdgtarget.update_attributes!(permitted_attributes(@sdgtarget))
+    if @sdgtarget.update_attributes!(permitted_attributes(@sdgtarget))
+      set_and_authorize_sdgtarget
+      render json: serialize(@sdgtarget)
+    end
   end
 
   # DELETE /sdgtargets/1

--- a/app/controllers/taxonomies_controller.rb
+++ b/app/controllers/taxonomies_controller.rb
@@ -30,6 +30,7 @@ class TaxonomiesController < ApplicationController
   # PATCH/PUT /taxonomies/1
   def update
     if @taxonomy.update_attributes!(permitted_attributes(@taxonomy))
+      set_and_authorize_taxonomy
       render json: serialize(@taxonomy)
     end
   end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe CategoriesController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:category) { FactoryGirl.create(:category) }
     subject do
       put :update,
@@ -169,6 +169,14 @@ RSpec.describe CategoriesController, type: :controller do
         sign_in user
         json = JSON.parse(subject.body)
         expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq user.id
+      end
+
+      it 'will return the latest last_modified_user_id', versioning: true do
+        expect(PaperTrail).to be_enabled
+        category.versions.first.update_column(:whodunnit, guest.id)
+        sign_in user
+        json = JSON.parse(subject.body)
+        expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq(user.id)
       end
 
       it 'will return an error if params are incorrect' do

--- a/spec/controllers/due_dates_controller_spec.rb
+++ b/spec/controllers/due_dates_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe DueDatesController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:due_date) { FactoryGirl.create(:due_date) }
     subject do
       put :update,

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe IndicatorsController, type: :controller do
     end
   end
 
-  describe 'Put update' do
-    let(:indicator) { FactoryGirl.create(:indicator) }
+  describe 'PUT update' do
+    let!(:indicator) { FactoryGirl.create(:indicator) }
     subject do
       put :update,
           format: :json,
@@ -165,7 +165,7 @@ RSpec.describe IndicatorsController, type: :controller do
         expect(subject).to be_ok
       end
 
-      it 'will reject and update where the last_updated_at is older than updated_at in the database' do
+      it 'will reject an update where the last_updated_at is older than updated_at in the database' do
         sign_in user
         indicator_get = get :show, params: { id: indicator }, format: :json
         json = JSON.parse(indicator_get.body)
@@ -192,6 +192,14 @@ RSpec.describe IndicatorsController, type: :controller do
         sign_in user
         json = JSON.parse(subject.body)
         expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq user.id
+      end
+
+      it 'will return the latest last_modified_user_id', versioning: true do
+        expect(PaperTrail).to be_enabled
+        indicator.versions.first.update_column(:whodunnit, contributor.id)
+        sign_in user
+        json = JSON.parse(subject.body)
+        expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq(user.id)
       end
 
       it 'will return an error if params are incorrect' do

--- a/spec/controllers/measures_controller_spec.rb
+++ b/spec/controllers/measures_controller_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe MeasuresController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:measure) { FactoryGirl.create(:measure) }
     subject do
       put :update,
@@ -225,6 +225,14 @@ RSpec.describe MeasuresController, type: :controller do
         sign_in user
         json = JSON.parse(subject.body)
         expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq user.id
+      end
+
+      it 'will return the latest last_modified_user_id', versioning: true do
+        expect(PaperTrail).to be_enabled
+        measure.versions.first.update_column(:whodunnit, contributor.id)
+        sign_in user
+        json = JSON.parse(subject.body)
+        expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq(user.id)
       end
 
       it 'will return an error if params are incorrect' do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe PagesController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:page) { FactoryGirl.create(:page) }
     subject do
       put :update,
@@ -179,6 +179,14 @@ RSpec.describe PagesController, type: :controller do
         sign_in admin
         json = JSON.parse(subject.body)
         expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq admin.id
+      end
+
+      it 'will return the latest last_modified_user_id', versioning: true do
+        expect(PaperTrail).to be_enabled
+        page.versions.first.update_column(:whodunnit, user.id)
+        sign_in admin
+        json = JSON.parse(subject.body)
+        expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq(admin.id)
       end
     end
   end

--- a/spec/controllers/progress_reports_controller_spec.rb
+++ b/spec/controllers/progress_reports_controller_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe ProgressReportsController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:progress_report) { FactoryGirl.create(:progress_report) }
 
     subject(:without_contributor_manager) do
@@ -234,6 +234,14 @@ RSpec.describe ProgressReportsController, type: :controller do
         sign_in user
         json = JSON.parse(subject.body)
         expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq user.id
+      end
+
+      it 'will return the latest last_modified_user_id', versioning: true do
+        expect(PaperTrail).to be_enabled
+        progress_report.versions.first.update_column(:whodunnit, contributor.id)
+        sign_in user
+        json = JSON.parse(subject.body)
+        expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq(user.id)
       end
 
       it 'will return an error if params are incorrect' do

--- a/spec/controllers/recommendation_measures_controller_spec.rb
+++ b/spec/controllers/recommendation_measures_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe RecommendationMeasuresController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:recommendation_measure) { FactoryGirl.create(:recommendation_measure) }
     subject do
       put :update,

--- a/spec/controllers/recommendations_controller_spec.rb
+++ b/spec/controllers/recommendations_controller_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe RecommendationsController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:recommendation) { FactoryGirl.create(:recommendation) }
     subject do
       put :update,
@@ -201,6 +201,14 @@ RSpec.describe RecommendationsController, type: :controller do
         sign_in user
         json = JSON.parse(subject.body)
         expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq user.id
+      end
+
+      it 'will return the latest last_modified_user_id', versioning: true do
+        expect(PaperTrail).to be_enabled
+        recommendation.versions.first.update_column(:whodunnit, contributor.id)
+        sign_in user
+        json = JSON.parse(subject.body)
+        expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq(user.id)
       end
 
       it 'will return an error if params are incorrect' do

--- a/spec/controllers/roles_controller.rb
+++ b/spec/controllers/roles_controller.rb
@@ -103,7 +103,7 @@ RSpec.describe RolesController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:role) { FactoryGirl.create(:role) }
     subject do
       put :update,

--- a/spec/controllers/sdgtargets_controller_spec.rb
+++ b/spec/controllers/sdgtargets_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe SdgtargetsController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:sdgtarget) { FactoryGirl.create(:sdgtarget) }
     subject do
       put :update,
@@ -192,6 +192,14 @@ RSpec.describe SdgtargetsController, type: :controller do
         sign_in user
         json = JSON.parse(subject.body)
         expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq user.id
+      end
+
+      it 'will return the latest last_modified_user_id', versioning: true do
+        expect(PaperTrail).to be_enabled
+        sdgtarget.versions.first.update_column(:whodunnit, contributor.id)
+        sign_in user
+        json = JSON.parse(subject.body)
+        expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq(user.id)
       end
 
       it 'will return an error if params are incorrect' do

--- a/spec/controllers/taxonomies_controller_spec.rb
+++ b/spec/controllers/taxonomies_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe TaxonomiesController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:taxonomy) { FactoryGirl.create(:taxonomy) }
     subject do
       put :update,

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe UsersController, type: :controller do
     end
   end
 
-  describe 'Put update' do
+  describe 'PUT update' do
     let(:guest) { FactoryGirl.create(:user, :contributor) }
     let(:contributor) { FactoryGirl.create(:user, :contributor) }
     let(:manager) { FactoryGirl.create(:user, :contributor) }


### PR DESCRIPTION
We have an issue since the performance improvements to #299 where the
latest last_modified_user_id wasn't being returned from PUT /update

This was due to the instance of the record not being reloaded after it
was updated given that last_modified_user_id is now a cached lookup
from the versions table.

By specifically reloading this in the controller we get the latest.