### PR TITLE
Simplify last_modified_user_id by caching it

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -52,7 +52,7 @@ class CategoriesController < ApplicationController
   end
 
   def base_object
-    Category.with_versions
+    Category
   end
 
   def serialize(target, serializer: CategorySerializer)

--- a/app/controllers/due_dates_controller.rb
+++ b/app/controllers/due_dates_controller.rb
@@ -49,7 +49,7 @@ class DueDatesController < ApplicationController
   end
 
   def base_object
-    DueDate.with_versions
+    DueDate
   end
 
   def serialize(target, serializer: DueDateSerializer)

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -51,7 +51,7 @@ class IndicatorsController < ApplicationController
       Measure.find(params[:measure_id]).indicators
     else
       Indicator
-    end.with_versions
+    end
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -55,7 +55,7 @@ class MeasuresController < ApplicationController
       Indicator.find(params[:indicator_id]).measures
     else
       Measure
-    end.with_versions
+    end
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -52,7 +52,7 @@ class PagesController < ApplicationController
   end
 
   def base_object
-    Page.with_versions
+    Page
   end
 
   def serialize(target, serializer: PageSerializer)

--- a/app/controllers/progress_reports_controller.rb
+++ b/app/controllers/progress_reports_controller.rb
@@ -53,7 +53,7 @@ class ProgressReportsController < ApplicationController
   end
 
   def base_object
-    ProgressReport.with_versions
+    ProgressReport
   end
 
   def serialize(target, serializer: ProgressReportSerializer)

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -53,7 +53,7 @@ class RecommendationsController < ApplicationController
       Measure.find(params[:measure_id]).recommendations
     else
       Recommendation
-    end.with_versions
+    end
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/sdgtargets_controller.rb
+++ b/app/controllers/sdgtargets_controller.rb
@@ -55,7 +55,7 @@ class SdgtargetsController < ApplicationController
       Indicator.find(params[:indicator_id]).measures
     else
       Sdgtarget
-    end.with_versions
+    end
   end
 
   def serialize(target, serializer: SdgtargetSerializer)

--- a/app/controllers/taxonomies_controller.rb
+++ b/app/controllers/taxonomies_controller.rb
@@ -49,7 +49,7 @@ class TaxonomiesController < ApplicationController
   end
 
   def base_object
-    Taxonomy.with_versions
+    Taxonomy
   end
 
   def serialize(target, serializer: TaxonomySerializer)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,13 +1,4 @@
 # frozen_string_literal: true
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
-
-  def last_modified_user_id
-    self[:last_modified_user_id] || calculate_last_modified_user_id
-  end
-
-  protected def calculate_last_modified_user_id
-    return nil unless respond_to?(:versions) && versions.last
-    versions.last.whodunnit
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,20 +1,10 @@
 # frozen_string_literal: true
-class User < ApplicationRecord
+class User < VersionedRecord
   # Include default devise modules.
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
   has_paper_trail ignore: [:tokens, :updated_at]
-
-  def last_modified_user_id
-    return nil unless respond_to?(:versions) && versions.last
-    versions.last.whodunnit
-  end
-
-  def last_modified_user
-    return nil unless last_modified_user_id
-    User.find last_modified_user_id
-  end
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/versioned_record.rb
+++ b/app/models/versioned_record.rb
@@ -3,6 +3,8 @@ require_relative 'application_record'
 class VersionedRecord < ApplicationRecord
   self.abstract_class = true
 
+  after_commit :cache_last_modified_user_id
+
   has_paper_trail
 
   def last_modified_user
@@ -10,14 +12,9 @@ class VersionedRecord < ApplicationRecord
     @last_modified_user ||= User.find(last_modified_user_id)
   end
 
-  scope :with_versions, -> do
-    select(
-      "#{quoted_table_name}.*," \
-      "(SELECT whodunnit FROM #{::PaperTrail::Version.quoted_table_name} " \
-      "WHERE #{::PaperTrail::Version.quoted_table_name}.item_type = '#{self.base_class.name}' " \
-      "AND #{::PaperTrail::Version.quoted_table_name}.item_id = #{quoted_table_name}.id " \
-      "ORDER BY #{::PaperTrail::Version.quoted_table_name}.created_at DESC " \
-      "LIMIT 1) last_modified_user_id"
-    )
+  private
+
+  def cache_last_modified_user_id
+    update_column(:last_modified_user_id, versions.last.whodunnit) if versions.last
   end
 end

--- a/app/models/versioned_record.rb
+++ b/app/models/versioned_record.rb
@@ -4,13 +4,9 @@ class VersionedRecord < ApplicationRecord
   self.abstract_class = true
 
   after_commit :cache_last_modified_user_id
+  belongs_to :last_modified_user, required: false
 
   has_paper_trail
-
-  def last_modified_user
-    return nil unless last_modified_user_id
-    @last_modified_user ||= User.find(last_modified_user_id)
-  end
 
   private
 

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,5 +1,5 @@
 class CategorySerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :title, :short_title, :description, :url, :draft, :reference, :taxonomy_id, :manager_id, :user_only
 

--- a/app/serializers/due_date_serializer.rb
+++ b/app/serializers/due_date_serializer.rb
@@ -1,5 +1,5 @@
 class DueDateSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :due_date, :draft, :indicator_id, :due, :overdue, :has_progress_report
 

--- a/app/serializers/fast_application_serializer.rb
+++ b/app/serializers/fast_application_serializer.rb
@@ -4,7 +4,6 @@ module FastApplicationSerializer
   def self.included(base)
     base.include FastJsonapi::ObjectSerializer
 
-    base.attribute :last_modified_user_id#, if: :current_user_has_permission?
     base.attribute :created_at do |object|
       object.created_at.in_time_zone.iso8601 if object.created_at
     end
@@ -12,9 +11,5 @@ module FastApplicationSerializer
     base.attribute :updated_at do |object|
       object.updated_at.in_time_zone.iso8601 if object.created_at
     end
-  end
-
-  def current_user_has_permission?
-    current_user && (current_user.role?('admin') || current_user.role?('manager'))
   end
 end

--- a/app/serializers/fast_versioned_serializer.rb
+++ b/app/serializers/fast_versioned_serializer.rb
@@ -1,0 +1,13 @@
+require_relative 'fast_application_serializer'
+
+module FastVersionedSerializer
+  def self.included(base)
+    base.include FastApplicationSerializer
+
+    base.attribute :last_modified_user_id#, if: :current_user_has_permission?
+  end
+
+  def current_user_has_permission?
+    current_user && (current_user.role?('admin') || current_user.role?('manager'))
+  end
+end

--- a/app/serializers/indicator_serializer.rb
+++ b/app/serializers/indicator_serializer.rb
@@ -1,5 +1,5 @@
 class IndicatorSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :title, :description, :reference, :draft, :manager_id, :frequency_months, :start_date, :repeat, :end_date
 

--- a/app/serializers/measure_serializer.rb
+++ b/app/serializers/measure_serializer.rb
@@ -1,5 +1,5 @@
 class MeasureSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :title, :description, :target_date, :draft, :outcome, :indicator_summary, :target_date_comment
 

--- a/app/serializers/page_serializer.rb
+++ b/app/serializers/page_serializer.rb
@@ -1,5 +1,5 @@
 class PageSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :title, :content, :menu_title, :order, :draft
 

--- a/app/serializers/progress_report_serializer.rb
+++ b/app/serializers/progress_report_serializer.rb
@@ -1,5 +1,5 @@
 class ProgressReportSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :indicator_id, :due_date_id, :title, :description, :document_url, :document_public, :draft
 

--- a/app/serializers/recommendation_serializer.rb
+++ b/app/serializers/recommendation_serializer.rb
@@ -1,5 +1,5 @@
 class RecommendationSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :title, :accepted, :response, :draft, :reference, :description
 

--- a/app/serializers/sdgtarget_serializer.rb
+++ b/app/serializers/sdgtarget_serializer.rb
@@ -1,5 +1,5 @@
 class SdgtargetSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :title, :description, :reference, :draft
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 class UserSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :email, :name
 

--- a/db/migrate/20180528083426_add_last_modified_user_id_to_versioned_records.rb
+++ b/db/migrate/20180528083426_add_last_modified_user_id_to_versioned_records.rb
@@ -1,0 +1,36 @@
+class AddLastModifiedUserIdToVersionedRecords < ActiveRecord::Migration[5.0]
+  def up
+    VERSIONED_MODELS.each do |model|
+      add_column model.table_name, :last_modified_user_id, :integer
+
+      model.reset_column_information
+
+      model.find_each do |record|
+        if record.versions.last
+          record.update_column(:last_modified_user_id, record.versions.last.whodunnit)
+        end
+      end
+    end
+  end
+
+  def down
+    VERSIONED_MODELS.each do |model|
+      remove_column model.table_name, :last_modified_user_id
+    end
+  end
+
+  private
+
+  VERSIONED_MODELS = [
+    Category,
+    DueDate,
+    Indicator,
+    Measure,
+    Page,
+    ProgressReport,
+    Recommendation,
+    Sdgtarget,
+    Taxonomy,
+    UserRole
+  ]
+end

--- a/db/migrate/20180528083426_add_last_modified_user_id_to_versioned_records.rb
+++ b/db/migrate/20180528083426_add_last_modified_user_id_to_versioned_records.rb
@@ -31,6 +31,7 @@ class AddLastModifiedUserIdToVersionedRecords < ActiveRecord::Migration[5.0]
     Recommendation,
     Sdgtarget,
     Taxonomy,
+    User,
     UserRole
   ]
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -250,6 +250,7 @@ ActiveRecord::Schema.define(version: 20180528083426) do
     t.string   "provider",               default: "email", null: false
     t.string   "uid",                    default: "",      null: false
     t.json     "tokens"
+    t.integer  "last_modified_user_id"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180508014642) do
+ActiveRecord::Schema.define(version: 20180528083426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,12 +21,13 @@ ActiveRecord::Schema.define(version: 20180508014642) do
     t.text     "description"
     t.string   "url"
     t.integer  "taxonomy_id"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.boolean  "draft",       default: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.boolean  "draft",                 default: false
     t.integer  "manager_id"
     t.string   "reference"
     t.boolean  "user_only"
+    t.integer  "last_modified_user_id"
     t.index ["draft"], name: "index_categories_on_draft", using: :btree
     t.index ["manager_id"], name: "index_categories_on_manager_id", using: :btree
     t.index ["taxonomy_id"], name: "index_categories_on_taxonomy_id", using: :btree
@@ -35,25 +36,27 @@ ActiveRecord::Schema.define(version: 20180508014642) do
   create_table "due_dates", force: :cascade do |t|
     t.integer  "indicator_id"
     t.date     "due_date"
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.boolean  "draft",        default: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.boolean  "draft",                 default: false
+    t.integer  "last_modified_user_id"
     t.index ["draft"], name: "index_due_dates_on_draft", using: :btree
     t.index ["indicator_id"], name: "index_due_dates_on_indicator_id", using: :btree
   end
 
   create_table "indicators", force: :cascade do |t|
-    t.text     "title",                            null: false
+    t.text     "title",                                 null: false
     t.text     "description"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.boolean  "draft",            default: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.boolean  "draft",                 default: false
     t.integer  "manager_id"
     t.integer  "frequency_months"
     t.date     "start_date"
-    t.boolean  "repeat",           default: false
+    t.boolean  "repeat",                default: false
     t.date     "end_date"
     t.string   "reference"
+    t.integer  "last_modified_user_id"
     t.index ["created_at"], name: "index_indicators_on_created_at", using: :btree
     t.index ["draft"], name: "index_indicators_on_draft", using: :btree
     t.index ["manager_id"], name: "index_indicators_on_manager_id", using: :btree
@@ -74,15 +77,16 @@ ActiveRecord::Schema.define(version: 20180508014642) do
   end
 
   create_table "measures", force: :cascade do |t|
-    t.text     "title",                               null: false
+    t.text     "title",                                 null: false
     t.text     "description"
     t.text     "target_date"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.boolean  "draft",               default: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.boolean  "draft",                 default: false
     t.text     "outcome"
     t.text     "indicator_summary"
     t.text     "target_date_comment"
+    t.integer  "last_modified_user_id"
     t.index ["draft"], name: "index_measures_on_draft", using: :btree
   end
 
@@ -90,10 +94,11 @@ ActiveRecord::Schema.define(version: 20180508014642) do
     t.string   "title"
     t.text     "content"
     t.string   "menu_title"
-    t.boolean  "draft",      default: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.boolean  "draft",                 default: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.integer  "order"
+    t.integer  "last_modified_user_id"
     t.index ["draft"], name: "index_pages_on_draft", using: :btree
   end
 
@@ -105,8 +110,9 @@ ActiveRecord::Schema.define(version: 20180508014642) do
     t.string   "document_url"
     t.boolean  "document_public"
     t.boolean  "draft"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+    t.integer  "last_modified_user_id"
     t.index ["due_date_id"], name: "index_progress_reports_on_due_date_id", using: :btree
     t.index ["indicator_id"], name: "index_progress_reports_on_indicator_id", using: :btree
   end
@@ -128,14 +134,15 @@ ActiveRecord::Schema.define(version: 20180508014642) do
   end
 
   create_table "recommendations", force: :cascade do |t|
-    t.text     "title",                       null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.boolean  "draft",       default: false
+    t.text     "title",                                 null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.boolean  "draft",                 default: false
     t.boolean  "accepted"
     t.text     "response"
-    t.text     "reference",                   null: false
+    t.text     "reference",                             null: false
     t.text     "description"
+    t.integer  "last_modified_user_id"
     t.index ["draft"], name: "index_recommendations_on_draft", using: :btree
   end
 
@@ -184,9 +191,10 @@ ActiveRecord::Schema.define(version: 20180508014642) do
     t.string   "reference"
     t.text     "title"
     t.text     "description"
-    t.boolean  "draft",       default: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.boolean  "draft",                 default: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.integer  "last_modified_user_id"
     t.index ["draft"], name: "index_sdgtargets_on_draft", using: :btree
   end
 
@@ -205,6 +213,7 @@ ActiveRecord::Schema.define(version: 20180508014642) do
     t.integer  "groups_measures_default"
     t.integer  "groups_recommendations_default"
     t.integer  "groups_sdgtargets_default"
+    t.integer  "last_modified_user_id"
   end
 
   create_table "user_categories", force: :cascade do |t|
@@ -215,10 +224,11 @@ ActiveRecord::Schema.define(version: 20180508014642) do
   end
 
   create_table "user_roles", force: :cascade do |t|
-    t.integer  "user_id",    null: false
-    t.integer  "role_id",    null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "user_id",               null: false
+    t.integer  "role_id",               null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+    t.integer  "last_modified_user_id"
     t.index ["role_id"], name: "index_user_roles_on_role_id", using: :btree
     t.index ["user_id"], name: "index_user_roles_on_user_id", using: :btree
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -183,6 +183,13 @@ RSpec.describe UsersController, type: :controller do
         expect(json['data']['attributes']['email']).to eq 'test@co.nz'
         expect(json['data']['attributes']['name']).to eq 'Sam'
       end
+
+      it 'will record what manager updated the user', versioning: true do
+        expect(PaperTrail).to be_enabled
+        sign_in admin
+        json = JSON.parse(subject.body)
+        expect(json['data']['attributes']['last_modified_user_id'].to_i).to eq admin.id
+      end
     end
   end
 


### PR DESCRIPTION
In order to reduce reading overhead we are now caching the
`last_modified_user_id` on save for each versioned record.  This allows
the queries to be simpler, and therefore faster, in most cases.

This increases overhead when writing but given the benefits of API
performance when reading it seems worth it.