### PR TITLE
Avoid cache_last_modified_user_id on DELETE

### DIFF
--- a/app/models/versioned_record.rb
+++ b/app/models/versioned_record.rb
@@ -3,7 +3,7 @@ require_relative 'application_record'
 class VersionedRecord < ApplicationRecord
   self.abstract_class = true
 
-  after_commit :cache_last_modified_user_id
+  after_commit :cache_last_modified_user_id, on: [:create, :update]
   belongs_to :last_modified_user, required: false
 
   has_paper_trail

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -210,6 +210,13 @@ RSpec.describe CategoriesController, type: :controller do
         sign_in user
         expect(subject).to be_no_content
       end
+
+      it 'response with success when versioned', versioning: true do
+        expect(PaperTrail).to be_enabled
+        category.update_attribute(:title, 'something else')
+        sign_in user
+        expect(subject.response_code).to eq(204)
+      end
     end
   end
 end


### PR DESCRIPTION
Previously we could hit a situation on a DELETE action where we would
try to `cache_last_modified_user_id` which is invalid because it's being
deleted.

Added a spec to categories which is where this issues was located.