### PR TITLE
bookmark type doesn't exist anymore

### DIFF
--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :bookmark do
     association :user
 
-    bookmark_type 1
     title Faker::Lorem.sentence
     view {{lorem: Faker::Lorem.sentence}}
   end


### PR DESCRIPTION
9 bookmark_controller_specs were failing due to the factory still having bookmark_type in it although that was removed from the model