### PR TITLE
Localise date format in due date mailer

### DIFF
--- a/app/mailers/due_date_mailer.rb
+++ b/app/mailers/due_date_mailer.rb
@@ -7,7 +7,7 @@ class DueDateMailer < ApplicationMailer
   def due(due_date)
     return unless due_date.manager_email
     @indicator = due_date.indicator
-    @due_date = due_date.due_date
+    @due_date = I18n.l(due_date.due_date)
     @manager_name = due_date.manager_name
     @client_url = ENV["CLIENT_URL"] || "https://undefined.client.url"
 
@@ -18,7 +18,7 @@ class DueDateMailer < ApplicationMailer
     return unless category.manager_email
     @indicator = due_date.indicator
     @category = category
-    @due_date = due_date.due_date
+    @due_date = I18n.l(due_date.due_date)
     @client_url = ENV["CLIENT_URL"] || "https://undefined.client.url"
 
     mail to: category.manager_email, subject: I18n.t("due_date_mailer.category_due.subject")
@@ -32,7 +32,7 @@ class DueDateMailer < ApplicationMailer
   def overdue(due_date)
     return unless due_date.manager_email
     @indicator = due_date.indicator
-    @due_date = due_date.due_date
+    @due_date = I18n.l(due_date.due_date)
     @manager_name = due_date.manager_name
     @client_url = ENV["CLIENT_URL"] || "https://undefined.client.url"
 
@@ -43,7 +43,7 @@ class DueDateMailer < ApplicationMailer
     return unless category.manager_email
     @indicator = due_date.indicator
     @category = category
-    @due_date = due_date.due_date
+    @due_date = I18n.l(due_date.due_date)
     @client_url = ENV["CLIENT_URL"] || "https://undefined.client.url"
 
     mail to: category.manager_email, subject: I18n.t("due_date_mailer.category_overdue.subject")

--- a/app/views/due_date_mailer/category_overdue.en.text.erb
+++ b/app/views/due_date_mailer/category_overdue.en.text.erb
@@ -1,6 +1,6 @@
 Progress report overdue for <%= @indicator.title %>
 
-Hi <%= @manager_name %>,
+Hi <%= @category.manager_name %>,
 
 A progress report was due on <%= @due_date %> for a Human Rights Body (<%= @category_title %>) you were assigned to: <%= @client_url %>/categories/<%= @category.id %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,8 @@ module HumanRightsNationalReporting
     config.active_record.belongs_to_required_by_default = true
 
     config.load_defaults = true
+
+    config.i18n.locale = ENV.fetch("LOCALE", "en-NZ")
+    config.i18n.fallbacks = true
   end
 end

--- a/config/locales/en-NZ.yml
+++ b/config/locales/en-NZ.yml
@@ -1,0 +1,7 @@
+---
+en-NZ:
+  date:
+    formats:
+      default: "%d/%m/%Y"
+      long: "%d %B %Y"
+      short: "%d %b"

--- a/spec/mailers/due_date_mailer_spec.rb
+++ b/spec/mailers/due_date_mailer_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 RSpec.describe DueDateMailer, type: :mailer do
+  let(:future_date) { Date.new(2035, 12, 25) }
+  let(:overdue_date) { Date.new(2019, 12, 25) }
+
   describe "due" do
     let(:manager) { FactoryBot.create(:user) }
-    let(:due_date) { FactoryBot.create(:due_date, manager: manager) }
+    let(:due_date) { FactoryBot.create(:due_date, due_date: future_date, manager: manager) }
     let(:mail) { DueDateMailer.due(due_date) }
 
     it "renders the headers" do
@@ -13,17 +16,24 @@ RSpec.describe DueDateMailer, type: :mailer do
     end
 
     it "mentions the managers name" do
-      expect(mail.body.encoded).to match(manager.name)
+      expect(mail.text_part.body).to match(manager.name)
+      expect(mail.html_part.body).to match(manager.name)
     end
 
     it "mentions the indicator title" do
-      expect(mail.body.encoded).to match(due_date.indicator.title)
+      expect(mail.text_part.body).to match(due_date.indicator.title)
+      expect(mail.html_part.body).to match(due_date.indicator.title)
+    end
+
+    it "localises the due date" do
+      expect(mail.text_part.body).to match("25/12/2035")
+      expect(mail.html_part.body).to match("25/12/2035")
     end
   end
 
   describe "overdue" do
     let(:manager) { FactoryBot.create(:user) }
-    let(:due_date) { FactoryBot.create(:due_date, manager: manager) }
+    let(:due_date) { FactoryBot.create(:due_date, due_date: overdue_date, manager: manager) }
     let(:mail) { DueDateMailer.overdue(due_date) }
 
     it "renders the headers" do
@@ -33,17 +43,24 @@ RSpec.describe DueDateMailer, type: :mailer do
     end
 
     it "mentions the managers name" do
-      expect(mail.body.encoded).to match(manager.name)
+      expect(mail.text_part.body).to match(manager.name)
+      expect(mail.html_part.body).to match(manager.name)
     end
 
     it "mentions the indicator title" do
-      expect(mail.body.encoded).to match(due_date.indicator.title)
+      expect(mail.text_part.body).to match(due_date.indicator.title)
+      expect(mail.html_part.body).to match(due_date.indicator.title)
+    end
+
+    it "localises the due date" do
+      expect(mail.text_part.body).to match("25/12/2019")
+      expect(mail.html_part.body).to match("25/12/2019")
     end
   end
 
   describe "category due" do
     let(:manager) { FactoryBot.create(:user) }
-    let(:due_date) { FactoryBot.create(:due_date) }
+    let(:due_date) { FactoryBot.create(:due_date, due_date: future_date) }
     let(:category) { FactoryBot.create(:category, manager: manager) }
     let(:mail) { DueDateMailer.category_due(due_date, category) }
 
@@ -54,17 +71,24 @@ RSpec.describe DueDateMailer, type: :mailer do
     end
 
     it "mentions the managers name" do
-      expect(mail.body.encoded).to match(manager.name)
+      expect(mail.text_part.body).to match(manager.name)
+      expect(mail.html_part.body).to match(manager.name)
     end
 
     it "mentions the indicator title" do
-      expect(mail.body.encoded).to match(due_date.indicator.title)
+      expect(mail.text_part.body).to match(due_date.indicator.title)
+      expect(mail.html_part.body).to match(due_date.indicator.title)
+    end
+
+    it "localises the due date" do
+      expect(mail.text_part.body).to match("25/12/2035")
+      expect(mail.html_part.body).to match("25/12/2035")
     end
   end
 
   describe "category over due" do
     let(:manager) { FactoryBot.create(:user) }
-    let(:due_date) { FactoryBot.create(:due_date) }
+    let(:due_date) { FactoryBot.create(:due_date, due_date: overdue_date) }
     let(:category) { FactoryBot.create(:category, manager: manager) }
     let(:mail) { DueDateMailer.category_overdue(due_date, category) }
 
@@ -75,11 +99,18 @@ RSpec.describe DueDateMailer, type: :mailer do
     end
 
     it "mentions the managers name" do
-      expect(mail.body.encoded).to match(manager.name)
+      expect(mail.text_part.body).to match(manager.name)
+      expect(mail.html_part.body).to match(manager.name)
     end
 
     it "mentions the indicator title" do
-      expect(mail.body.encoded).to match(due_date.indicator.title)
+      expect(mail.text_part.body).to match(due_date.indicator.title)
+      expect(mail.html_part.body).to match(due_date.indicator.title)
+    end
+
+    it "localises the due date" do
+      expect(mail.text_part.body).to match("25/12/2019")
+      expect(mail.html_part.body).to match("25/12/2019")
     end
   end
 end


### PR DESCRIPTION
Fixes #368 by localising due dates into the NZ `date_format`.

While implementing this, I noticed that the due date mailer had a few
issues in the implementation and the specs, so I've fixed these.