### PR TITLE
Set `I18n.locale` in the job running environment.

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
+# For some reason this isn't set properly in the job environment
+I18n.locale = Rails.application.config.i18n.locale
+
 class ApplicationJob < ActiveJob::Base
 end

--- a/spec/mailers/due_date_mailer_spec.rb
+++ b/spec/mailers/due_date_mailer_spec.rb
@@ -1,3 +1,4 @@
+require "cgi"
 require "rails_helper"
 
 RSpec.describe DueDateMailer, type: :mailer do
@@ -17,7 +18,7 @@ RSpec.describe DueDateMailer, type: :mailer do
 
     it "mentions the managers name" do
       expect(mail.text_part.body).to match(manager.name)
-      expect(mail.html_part.body).to match(manager.name)
+      expect(mail.html_part.body).to match(CGI.escapeHTML(manager.name))
     end
 
     it "mentions the indicator title" do
@@ -44,7 +45,7 @@ RSpec.describe DueDateMailer, type: :mailer do
 
     it "mentions the managers name" do
       expect(mail.text_part.body).to match(manager.name)
-      expect(mail.html_part.body).to match(manager.name)
+      expect(mail.html_part.body).to match(CGI.escapeHTML(manager.name))
     end
 
     it "mentions the indicator title" do
@@ -72,7 +73,7 @@ RSpec.describe DueDateMailer, type: :mailer do
 
     it "mentions the managers name" do
       expect(mail.text_part.body).to match(manager.name)
-      expect(mail.html_part.body).to match(manager.name)
+      expect(mail.html_part.body).to match(CGI.escapeHTML(manager.name))
     end
 
     it "mentions the indicator title" do
@@ -100,7 +101,7 @@ RSpec.describe DueDateMailer, type: :mailer do
 
     it "mentions the managers name" do
       expect(mail.text_part.body).to match(manager.name)
-      expect(mail.html_part.body).to match(manager.name)
+      expect(mail.html_part.body).to match(CGI.escapeHTML(manager.name))
     end
 
     it "mentions the indicator title" do


### PR DESCRIPTION
We noticed that the `DueDateMailer` was sending emails with dates that
were not localised into `en-NZ`.  

As it turns out, the job runner's locale was not the same as the
application's locale so setting this in the `ApplicationJob` file fixes
the issue.

Fixes #368