### PR TITLE
Switch from setting `I18n.locale` to using `I18n.with_locale`

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
 
-# For some reason this isn't set properly in the job environment
-I18n.locale = Rails.application.config.i18n.locale
-
 class ApplicationJob < ActiveJob::Base
 end

--- a/app/mailers/due_date_mailer.rb
+++ b/app/mailers/due_date_mailer.rb
@@ -7,7 +7,9 @@ class DueDateMailer < ApplicationMailer
   def due(due_date)
     return unless due_date.manager_email
     @indicator = due_date.indicator
-    @due_date = I18n.l(due_date.due_date)
+    I18n.with_locale(Rails.application.config.i18n.locale) do
+      @due_date = I18n.l(due_date.due_date)
+    end
     @manager_name = due_date.manager_name
     @client_url = ENV["CLIENT_URL"] || "https://undefined.client.url"
 
@@ -18,7 +20,9 @@ class DueDateMailer < ApplicationMailer
     return unless category.manager_email
     @indicator = due_date.indicator
     @category = category
-    @due_date = I18n.l(due_date.due_date)
+    I18n.with_locale(Rails.application.config.i18n.locale) do
+      @due_date = I18n.l(due_date.due_date)
+    end
     @client_url = ENV["CLIENT_URL"] || "https://undefined.client.url"
 
     mail to: category.manager_email, subject: I18n.t("due_date_mailer.category_due.subject")
@@ -32,7 +36,9 @@ class DueDateMailer < ApplicationMailer
   def overdue(due_date)
     return unless due_date.manager_email
     @indicator = due_date.indicator
-    @due_date = I18n.l(due_date.due_date)
+    I18n.with_locale(Rails.application.config.i18n.locale) do
+      @due_date = I18n.l(due_date.due_date)
+    end
     @manager_name = due_date.manager_name
     @client_url = ENV["CLIENT_URL"] || "https://undefined.client.url"
 
@@ -43,7 +49,9 @@ class DueDateMailer < ApplicationMailer
     return unless category.manager_email
     @indicator = due_date.indicator
     @category = category
-    @due_date = I18n.l(due_date.due_date)
+    I18n.with_locale(Rails.application.config.i18n.locale) do
+      @due_date = I18n.l(due_date.due_date)
+    end
     @client_url = ENV["CLIENT_URL"] || "https://undefined.client.url"
 
     mail to: category.manager_email, subject: I18n.t("due_date_mailer.category_overdue.subject")


### PR DESCRIPTION
When sending emails using the clockwork scheduler the `I18n.locale` is 
still not being picked up properly, so we can switch to using the block
level `I18n.with_locale` which lets us supply the locale to use for the
current block of code.