### PR TITLE
Ensure that emails and domains are visible at appropriate times

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,12 +46,12 @@ class UsersController < ApplicationController
   end
 
   def serialize(target, serializer: UserSerializer)
-    return super if policy(target).show_email?
+    return super if base_object === target && policy(target).show_email?
 
     JSON.parse(super).tap do |json|
       if Array === json["data"]
         json["data"].each do |data|
-          data["attributes"].delete("email")
+          data["attributes"].delete("email") unless policy(base_object.new(id: data["id"])).show_email?
         end
       else
         json["data"]["attributes"].delete("email")

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -24,7 +24,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def show_email?
-    @user.role?("admin") || @record == @user
+    @user.role?("admin") || @record.id == @user.id
   end
 
   class Scope < Scope

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe UsersController, type: :controller do
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(1)
         expect(json["data"][0]["id"]).to eq(guest.id.to_s)
+        expect(json["data"][0]["attributes"]["email"]).to eq(guest.email)
+        expect(json["data"][0]["attributes"]["domain"]).to eq(guest.domain)
       end
 
       it "shows only themselves for contributors" do
@@ -39,9 +41,10 @@ RSpec.describe UsersController, type: :controller do
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(1)
         expect(json["data"][0]["id"]).to eq(contributor.id.to_s)
+        expect(json["data"][0]["attributes"]["email"]).to eq(contributor.email)
       end
 
-      it "shows all users for managers" do
+      it "shows all users for managers, with only the manager's email" do
         contributor
         contributor2
         manager
@@ -52,9 +55,37 @@ RSpec.describe UsersController, type: :controller do
         sign_in manager
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(7)
+
+        contributor_data = json["data"].find { |d| d["id"] == contributor.id.to_s }
+        expect(contributor_data["attributes"]["email"]).to be_nil
+        expect(contributor_data["attributes"]["domain"]).to eq(contributor.domain)
+
+        contributor2_data = json["data"].find { |d| d["id"] == contributor2.id.to_s }
+        expect(contributor2_data["attributes"]["email"]).to be_nil
+        expect(contributor2_data["attributes"]["domain"]).to eq(contributor2.domain)
+
+        manager_data = json["data"].find { |d| d["id"] == manager.id.to_s }
+        expect(manager_data["attributes"]["email"]).to eq(manager.email)
+        expect(manager_data["attributes"]["domain"]).to eq(manager.domain)
+
+        manager2_data = json["data"].find { |d| d["id"] == manager2.id.to_s }
+        expect(manager2_data["attributes"]["email"]).to be_nil
+        expect(manager2_data["attributes"]["domain"]).to eq(manager2.domain)
+
+        admin_data = json["data"].find { |d| d["id"] == admin.id.to_s }
+        expect(admin_data["attributes"]["email"]).to be_nil
+        expect(admin_data["attributes"]["domain"]).to eq(admin.domain)
+
+        admin2_data = json["data"].find { |d| d["id"] == admin2.id.to_s }
+        expect(admin2_data["attributes"]["email"]).to be_nil
+        expect(admin2_data["attributes"]["domain"]).to eq(admin2.domain)
+
+        guest_data = json["data"].find { |d| d["id"] == guest.id.to_s }
+        expect(guest_data["attributes"]["email"]).to be_nil
+        expect(guest_data["attributes"]["domain"]).to eq(guest.domain)
       end
 
-      it "shows all users for admin" do
+      it "shows all users for admin, including all email addresses" do
         contributor
         contributor2
         manager
@@ -64,6 +95,34 @@ RSpec.describe UsersController, type: :controller do
         sign_in admin
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(7)
+
+        contributor_data = json["data"].find { |d| d["id"] == contributor.id.to_s }
+        expect(contributor_data["attributes"]["email"]).to eq(contributor.email)
+        expect(contributor_data["attributes"]["domain"]).to eq(contributor.domain)
+
+        contributor2_data = json["data"].find { |d| d["id"] == contributor2.id.to_s }
+        expect(contributor2_data["attributes"]["email"]).to eq(contributor2.email)
+        expect(contributor2_data["attributes"]["domain"]).to eq(contributor2.domain)
+
+        manager_data = json["data"].find { |d| d["id"] == manager.id.to_s }
+        expect(manager_data["attributes"]["email"]).to eq(manager.email)
+        expect(manager_data["attributes"]["domain"]).to eq(manager.domain)
+
+        manager2_data = json["data"].find { |d| d["id"] == manager2.id.to_s }
+        expect(manager2_data["attributes"]["email"]).to eq(manager2.email)
+        expect(manager2_data["attributes"]["domain"]).to eq(manager2.domain)
+
+        admin_data = json["data"].find { |d| d["id"] == admin.id.to_s }
+        expect(admin_data["attributes"]["email"]).to eq(admin.email)
+        expect(admin_data["attributes"]["domain"]).to eq(admin.domain)
+
+        admin2_data = json["data"].find { |d| d["id"] == admin2.id.to_s }
+        expect(admin2_data["attributes"]["email"]).to eq(admin2.email)
+        expect(admin2_data["attributes"]["domain"]).to eq(admin2.domain)
+
+        guest_data = json["data"].find { |d| d["id"] == guest.id.to_s }
+        expect(guest_data["attributes"]["email"]).to eq(guest.email)
+        expect(guest_data["attributes"]["domain"]).to eq(guest.domain)
       end
     end
   end

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -43,9 +43,11 @@ RSpec.describe Indicator, type: :model do
 end
 context "a due_date has a progress_report" do
   let(:indicator) {
-    indicator = FactoryBot.create(:indicator, :with_12_due_dates)
-    warn "created first 12"
-    indicator
+    Timecop.travel(2019, 1, 1) do
+      indicator = FactoryBot.create(:indicator, :with_12_due_dates)
+      warn "created first 12"
+      indicator
+    end
   }
   let!(:progress_report) { FactoryBot.create(:progress_report, indicator: indicator, title: "test", due_date: indicator.due_dates.last) }
 


### PR DESCRIPTION
Following on from #364 we want to ensure that when retrieving a group of
users that we apply the right email and domain visibility policy.

Resolves #364.