### PR TITLE
Enforce `reference` uniqueness for `indicators`, `measures`, `recommendations`

### DIFF
--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -2,6 +2,7 @@ class Indicator < VersionedRecord
   validates :title, presence: true
   validates :end_date, presence: true, if: :repeat?
   validates :frequency_months, presence: true, if: :repeat?
+  validates :reference, uniqueness: true
   validate :end_date_after_start_date, if: :end_date?
 
   after_create :build_due_dates

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -20,4 +20,5 @@ class Measure < VersionedRecord
   accepts_nested_attributes_for :measure_categories
 
   validates :title, presence: true
+  validates :reference, uniqueness: true
 end

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -23,5 +23,5 @@ class Recommendation < VersionedRecord
   accepts_nested_attributes_for :recommendation_categories
 
   validates :title, presence: true
-  validates :reference, presence: true
+  validates :reference, presence: true, uniqueness: true
 end

--- a/db/migrate/20240505021300_enforce_reference_uniqueness_on_indicators_measures_recommendations.rb
+++ b/db/migrate/20240505021300_enforce_reference_uniqueness_on_indicators_measures_recommendations.rb
@@ -1,0 +1,7 @@
+class EnforceReferenceUniquenessOnIndicatorsMeasuresRecommendations < ActiveRecord::Migration[6.1]
+  def change
+    add_index :indicators, :reference, unique: true
+    add_index :measures, :reference, unique: true
+    add_index :recommendations, :reference, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_10_041747) do
+ActiveRecord::Schema.define(version: 2024_05_05_021300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 2024_02_10_041747) do
     t.index ["created_at"], name: "index_indicators_on_created_at"
     t.index ["draft"], name: "index_indicators_on_draft"
     t.index ["manager_id"], name: "index_indicators_on_manager_id"
+    t.index ["reference"], name: "index_indicators_on_reference", unique: true
   end
 
   create_table "measure_categories", id: :serial, force: :cascade do |t|
@@ -146,6 +147,7 @@ ActiveRecord::Schema.define(version: 2024_02_10_041747) do
     t.bigint "relationship_updated_by_id"
     t.string "reference"
     t.index ["draft"], name: "index_measures_on_draft"
+    t.index ["reference"], name: "index_measures_on_reference", unique: true
   end
 
   create_table "pages", id: :serial, force: :cascade do |t|
@@ -237,6 +239,7 @@ ActiveRecord::Schema.define(version: 2024_02_10_041747) do
     t.datetime "relationship_updated_at", precision: 6
     t.index ["draft"], name: "index_recommendations_on_draft"
     t.index ["framework_id"], name: "index_recommendations_on_framework_id"
+    t.index ["reference"], name: "index_recommendations_on_reference", unique: true
   end
 
   create_table "roles", id: :serial, force: :cascade do |t|

--- a/spec/factories/indicators.rb
+++ b/spec/factories/indicators.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :indicator do
     title { Faker::Lorem.sentence }
     description { Faker::Hipster.sentence }
+    sequence(:reference) { Faker::Creature::Dog.breed + _1.to_s }
 
     trait :without_measure do
       measures { [] }

--- a/spec/factories/measures.rb
+++ b/spec/factories/measures.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :measure do
     title { Faker::Creature::Cat.registry }
     description { Faker::Beer.name }
+    sequence(:reference) { Faker::Creature::Dog.breed + _1.to_s }
     target_date { Faker::Date.forward(days: 450) }
 
     trait :without_recommendation do

--- a/spec/factories/recommendations.rb
+++ b/spec/factories/recommendations.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :recommendation do
     title { Faker::Superhero.name }
-    reference { "1" }
+    sequence(:reference) { Faker::Creature::Dog.breed + _1.to_s }
 
     trait :without_category do
       categories { [] }

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -2,6 +2,14 @@ require "rails_helper"
 
 RSpec.describe Indicator, type: :model do
   it { is_expected.to validate_presence_of :title }
+
+  it "validates uniqueness of reference" do
+    FactoryBot.create(:indicator, reference: "123")
+
+    expect(FactoryBot.build(:indicator, reference: "123")).to be_invalid
+    expect(FactoryBot.build(:indicator, reference: "456")).to be_valid
+  end
+
   it { is_expected.to have_many :measures }
   it { is_expected.to have_many :progress_reports }
   it { is_expected.to have_many :due_dates }

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -2,6 +2,14 @@ require "rails_helper"
 
 RSpec.describe Measure, type: :model do
   it { is_expected.to validate_presence_of :title }
+
+  it "validates uniqueness of reference" do
+    FactoryBot.create(:measure, reference: "123")
+
+    expect(FactoryBot.build(:measure, reference: "123")).to be_invalid
+    expect(FactoryBot.build(:measure, reference: "456")).to be_valid
+  end
+
   it { is_expected.to have_many :recommendations }
   it { is_expected.to have_many :categories }
   it { is_expected.to have_many :indicators }

--- a/spec/models/recommendation_spec.rb
+++ b/spec/models/recommendation_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe Recommendation, type: :model do
   it { is_expected.to validate_presence_of :title }
   it { is_expected.to validate_presence_of :reference }
 
+  it "validates uniqueness of reference" do
+    FactoryBot.create(:recommendation, reference: "123")
+
+    expect(FactoryBot.build(:recommendation, reference: "123")).to be_invalid
+    expect(FactoryBot.build(:recommendation, reference: "456")).to be_valid
+  end
+
   it { is_expected.to have_many :categories }
   it { is_expected.to have_many :measures }
   it { is_expected.to have_many :indicators }


### PR DESCRIPTION
We want to make sure that the `reference` is unique for `indicators`,
`measures`, and `recommendations` so this adds a validation to each of
the models and also a unique index to the database table.

Closes #395 