### PR TITLE
Notify category manager when progress report updated

### DIFF
--- a/app/jobs/send_progress_report_updated_emails_job.rb
+++ b/app/jobs/send_progress_report_updated_emails_job.rb
@@ -1,0 +1,7 @@
+class SendProgressReportUpdatedEmailsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    ProgressReport.send_all_updated_emails
+  end
+end

--- a/app/mailers/progress_report_mailer.rb
+++ b/app/mailers/progress_report_mailer.rb
@@ -4,13 +4,14 @@ class ProgressReportMailer < ApplicationMailer
   #
   #   en.progress_report_mailer.updated.subject
   #
-  def updated(progress_report)
-    return if progress_report.manager_email.blank?
+  def updated(progress_report, category)
+    return if category.manager_email.blank?
 
+    @category = category
     @indicator = progress_report.indicator
-    @manager_name = progress_report.manager_name
+    @manager_name = @category.manager_name
     @client_url = ENV.fetch("CLIENT_URL", "https://undefined.client.url")
 
-    mail to: progress_report.manager_email, subject: I18n.t("progress_report_mailer.updated.subject")
+    mail to: @category.manager_email, subject: I18n.t("progress_report_mailer.updated.subject")
   end
 end

--- a/app/mailers/progress_report_mailer.rb
+++ b/app/mailers/progress_report_mailer.rb
@@ -1,0 +1,16 @@
+class ProgressReportMailer < ApplicationMailer
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.progress_report_mailer.updated.subject
+  #
+  def updated(progress_report)
+    return if progress_report.manager_email.blank?
+
+    @indicator = progress_report.indicator
+    @manager_name = progress_report.manager_name
+    @client_url = ENV.fetch("CLIENT_URL", "https://undefined.client.url")
+
+    mail to: progress_report.manager_email, subject: I18n.t("progress_report_mailer.updated.subject")
+  end
+end

--- a/app/mailers/progress_report_mailer.rb
+++ b/app/mailers/progress_report_mailer.rb
@@ -8,6 +8,7 @@ class ProgressReportMailer < ApplicationMailer
     return if category.manager_email.blank?
 
     @category = category
+    @progress_report = progress_report
     @indicator = progress_report.indicator
     @manager_name = @category.manager_name
     @client_url = ENV.fetch("CLIENT_URL", "https://undefined.client.url")

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -48,6 +48,12 @@ class Category < VersionedRecord
     end
   end
 
+  def self_and_ancestors
+    return [self] if parent_id.nil?
+
+    [self, *category.self_and_ancestors]
+  end
+
   def self.send_all_due_emails
     Category.all.each(&:send_due_emails)
   end

--- a/app/models/progress_report.rb
+++ b/app/models/progress_report.rb
@@ -18,6 +18,7 @@ class ProgressReport < VersionedRecord
 
   def send_updated_emails
     categories
+      .flat_map(&:self_and_ancestors)
       .reject { _1.updated_by_id == _1.manager_id }
       .each do |category|
         ProgressReportMailer.updated(self, category).deliver_now

--- a/app/models/progress_report.rb
+++ b/app/models/progress_report.rb
@@ -5,15 +5,30 @@ class ProgressReport < VersionedRecord
   has_many :recommendations, through: :measures
   has_many :categories, through: :recommendations
   has_one :manager, through: :indicator
+  delegate :email, to: :manager, prefix: true, allow_nil: true
+  delegate :name, to: :manager, prefix: true, allow_nil: true
 
   validates :title, presence: true
   validates :indicator_id, presence: true
 
   validate :indicator_id_must_not_change, if: [:persisted?, :indicator_id_changed?]
 
+  def self.send_all_updated_emails
+    joins(:versions)
+      .where(versions: {
+        created_at: 24.hours.ago..,
+        whodunnit: User.joins(:roles).where(roles: {name: "contributor"}).pluck(:id)
+      })
+      .each(&:send_updated_emails)
+  end
+
   private
 
   def indicator_id_must_not_change
     errors.add(:indicator_id, "cannot be changed after the report has been created")
+  end
+
+  def send_updated_emails
+    ProgressReportMailer.updated(self).deliver_now
   end
 end

--- a/app/views/due_date_mailer/category_overdue.en.text.erb
+++ b/app/views/due_date_mailer/category_overdue.en.text.erb
@@ -2,7 +2,7 @@ Progress report overdue for <%= @indicator.title %>
 
 Hi <%= @category.manager_name %>,
 
-A progress report was due on <%= @due_date %> for a Human Rights Body (<%= @category_title %>) you were assigned to: <%= @client_url %>/categories/<%= @category.id %>
+A progress report was due on <%= @due_date %> for a Human Rights Body (<%= @category.title %>) you were assigned to: <%= @client_url %>/categories/<%= @category.id %>
 
 Visit the indicator page to review due dates and progress reports: <%= @client_url %>/indicators/<%= @indicator.id %>.
 

--- a/app/views/progress_report_mailer/updated.en.html.erb
+++ b/app/views/progress_report_mailer/updated.en.html.erb
@@ -1,0 +1,17 @@
+<h3>Progress report updated for <%= @indicator.title %></h3>
+
+<p>
+  Hi <%= @progress_report.manager_name %>,
+</p>
+
+<p>
+  A progress report was updated for a Human Rights Body (<a href="<%= @client_url %>/categories/<%= @category.id %>"><%= @category.title %></a>) you were assigned to.
+</p>
+
+<p>
+  Visit the <a href="<%= @client_url %>/indicators/<%= @indicator.id %>">indicator page</a> to review progress reports.
+</p>
+
+<p>
+  Thank you!
+</p>

--- a/app/views/progress_report_mailer/updated.en.html.erb
+++ b/app/views/progress_report_mailer/updated.en.html.erb
@@ -1,15 +1,15 @@
-<h3>Progress report updated for <%= @indicator.title %></h3>
+<h3>Progress report added or updated for <%= @indicator.title %></h3>
 
 <p>
   Hi <%= @manager_name %>,
 </p>
 
 <p>
-  A progress report was updated for a Human Rights Body (<a href="<%= @client_url %>/categories/<%= @category.id %>"><%= @category.title %></a>) you were assigned to.
+  A progress report was added or updated for a Human Rights Body (<a href="<%= @client_url %>/categories/<%= @category.id %>"><%= @category.title %></a>) you were assigned to.
 </p>
 
 <p>
-  Visit the <a href="<%= @client_url %>/progress_reports/<%= @progress_report.id %>">progress report</a> page.
+You can review and publish the progress report here: <a href="<%= @client_url %>/reports/<%= @progress_report.id %>"><%= @progress_report.title %></a>.
 </p>
 
 <p>

--- a/app/views/progress_report_mailer/updated.en.html.erb
+++ b/app/views/progress_report_mailer/updated.en.html.erb
@@ -1,7 +1,7 @@
 <h3>Progress report updated for <%= @indicator.title %></h3>
 
 <p>
-  Hi <%= @progress_report.manager_name %>,
+  Hi <%= @manager_name %>,
 </p>
 
 <p>

--- a/app/views/progress_report_mailer/updated.en.html.erb
+++ b/app/views/progress_report_mailer/updated.en.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <p>
-  Visit the <a href="<%= @client_url %>/indicators/<%= @indicator.id %>">indicator page</a> to review progress reports.
+  Visit the <a href="<%= @client_url %>/progress_reports/<%= @progress_report.id %>">progress report</a> page.
 </p>
 
 <p>

--- a/app/views/progress_report_mailer/updated.en.text.erb
+++ b/app/views/progress_report_mailer/updated.en.text.erb
@@ -4,6 +4,6 @@ Hi <%= @manager_name %>,
 
 A progress report was updated for a Human Rights Body (<%= @category.title %>) you were assigned to: <%= @client_url %>/categories/<%= @category.id %>
 
-Visit the indicator page to review progress reports: <%= @client_url %>/indicators/<%= @indicator.id %>.
+Visit the progress report page: <%= @client_url %>/progress_reports/<%= @progress_report.id %>
 
 Thank you!

--- a/app/views/progress_report_mailer/updated.en.text.erb
+++ b/app/views/progress_report_mailer/updated.en.text.erb
@@ -1,0 +1,9 @@
+Progress report updated for <%= @indicator.title %>
+
+Hi <%= @progress_report.manager_name %>,
+
+A progress report was updated for a Human Rights Body (<%= @category.title %>) you were assigned to: <%= @client_url %>/categories/<%= @category.id %>
+
+Visit the indicator page to review progress reports: <%= @client_url %>/indicators/<%= @indicator.id %>.
+
+Thank you!

--- a/app/views/progress_report_mailer/updated.en.text.erb
+++ b/app/views/progress_report_mailer/updated.en.text.erb
@@ -1,6 +1,6 @@
 Progress report updated for <%= @indicator.title %>
 
-Hi <%= @progress_report.manager_name %>,
+Hi <%= @manager_name %>,
 
 A progress report was updated for a Human Rights Body (<%= @category.title %>) you were assigned to: <%= @client_url %>/categories/<%= @category.id %>
 

--- a/app/views/progress_report_mailer/updated.en.text.erb
+++ b/app/views/progress_report_mailer/updated.en.text.erb
@@ -1,9 +1,9 @@
-Progress report updated for <%= @indicator.title %>
+Progress report added or updated for <%= @indicator.title %>
 
 Hi <%= @manager_name %>,
 
-A progress report was updated for a Human Rights Body (<%= @category.title %>) you were assigned to: <%= @client_url %>/categories/<%= @category.id %>
+A progress report was added or updated for a Human Rights Body (<%= @category.title %>) you were assigned to: <%= @client_url %>/categories/<%= @category.id %>
 
-Visit the progress report page: <%= @client_url %>/progress_reports/<%= @progress_report.id %>
+You can review and publish the progress report here: <%= @client_url %>/reports/<%= @progress_report.id %>
 
 Thank you!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,3 +15,6 @@ en:
       subject: Progress report is due
     overdue:
       subject: Progress report is overdue
+  progress_report_mailer:
+    updated:
+      subject: Progress report has been updated

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,4 +17,4 @@ en:
       subject: Progress report is overdue
   progress_report_mailer:
     updated:
-      subject: Progress report has been updated
+      subject: A progress report has been added or updated

--- a/scheduler.rb
+++ b/scheduler.rb
@@ -15,6 +15,10 @@ module Clockwork
     SendCategoryOverdueEmailsJob.perform_now
   end
 
+  every(1.day, "Send Progress Report Updated Emails", at: "00:00", tz: Rails.application.config.time_zone) do
+    SendProgressReportUpdatedEmailsJob.perform_now
+  end
+
   error_handler do |error|
   end
 end

--- a/spec/mailers/progress_report_mailer_spec.rb
+++ b/spec/mailers/progress_report_mailer_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe ProgressReportMailer, type: :mailer do
     end
 
     it "links to the progress report" do
-      expect(mail.text_part.body).to match("/progress_reports/#{progress_report_with_contributor.id}")
-      expect(mail.html_part.body).to match("/progress_reports/#{progress_report_with_contributor.id}")
+      expect(mail.text_part.body).to match("/reports/#{progress_report_with_contributor.id}")
+      expect(mail.html_part.body).to match("/reports/#{progress_report_with_contributor.id}")
     end
   end
 end

--- a/spec/mailers/progress_report_mailer_spec.rb
+++ b/spec/mailers/progress_report_mailer_spec.rb
@@ -1,0 +1,27 @@
+require "cgi"
+require "rails_helper"
+
+RSpec.describe ProgressReportMailer, type: :mailer do
+  describe "updated" do
+    let(:manager) { FactoryBot.create(:user) }
+    let(:indicator) { FactoryBot.create(:indicator, manager:) }
+    let(:progress_report) { FactoryBot.create(:progress_report, indicator:) }
+    let(:mail) { described_class.updated(progress_report) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t("progress_report_mailer.updated.subject"))
+      expect(mail.to).to eq([manager.email])
+      expect(mail.from).to eq(["no-reply@mail.impactoss.org"])
+    end
+
+    it "mentions the manager's name" do
+      expect(mail.text_part.body).to match(manager.name)
+      expect(mail.html_part.body).to match(CGI.escapeHTML(manager.name))
+    end
+
+    it "mentions the indicator title" do
+      expect(mail.text_part.body).to match(due_date.indicator.title)
+      expect(mail.html_part.body).to match(due_date.indicator.title)
+    end
+  end
+end

--- a/spec/mailers/progress_report_mailer_spec.rb
+++ b/spec/mailers/progress_report_mailer_spec.rb
@@ -3,10 +3,20 @@ require "rails_helper"
 
 RSpec.describe ProgressReportMailer, type: :mailer do
   describe "updated" do
-    let(:manager) { FactoryBot.create(:user) }
-    let(:indicator) { FactoryBot.create(:indicator, manager:) }
-    let(:progress_report) { FactoryBot.create(:progress_report, indicator:) }
-    let(:mail) { described_class.updated(progress_report) }
+    let(:category) { FactoryBot.create(:category, manager:) }
+    let(:measure) { FactoryBot.create(:measure) }
+    let(:recommendation) { FactoryBot.create(:recommendation) }
+    let(:guest) { FactoryBot.create(:user) }
+    let(:manager) { FactoryBot.create(:user, :manager) }
+    let(:contributor) { FactoryBot.create(:user, :contributor) }
+    let(:contributor_indicator) { FactoryBot.create(:indicator, manager: contributor) }
+    let(:progress_report_with_contributor) { FactoryBot.create(:progress_report, indicator: contributor_indicator) }
+    let(:mail) { described_class.updated(progress_report_with_contributor, category) }
+
+    before do
+      measure.indicators << contributor_indicator
+      recommendation.measures << measure
+    end
 
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("progress_report_mailer.updated.subject"))
@@ -20,8 +30,8 @@ RSpec.describe ProgressReportMailer, type: :mailer do
     end
 
     it "mentions the indicator title" do
-      expect(mail.text_part.body).to match(due_date.indicator.title)
-      expect(mail.html_part.body).to match(due_date.indicator.title)
+      expect(mail.text_part.body).to match(contributor_indicator.title)
+      expect(mail.html_part.body).to match(contributor_indicator.title)
     end
   end
 end

--- a/spec/mailers/progress_report_mailer_spec.rb
+++ b/spec/mailers/progress_report_mailer_spec.rb
@@ -33,5 +33,10 @@ RSpec.describe ProgressReportMailer, type: :mailer do
       expect(mail.text_part.body).to match(contributor_indicator.title)
       expect(mail.html_part.body).to match(contributor_indicator.title)
     end
+
+    it "links to the progress report" do
+      expect(mail.text_part.body).to match("/progress_reports/#{progress_report_with_contributor.id}")
+      expect(mail.html_part.body).to match("/progress_reports/#{progress_report_with_contributor.id}")
+    end
   end
 end

--- a/spec/models/progress_report_spec.rb
+++ b/spec/models/progress_report_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe ProgressReport, type: :model do
 
   describe "#send_updated_emails" do
     let(:categories) { FactoryBot.create_list(:category, 5) }
+    let(:child_categories) do
+      categories.map {
+        FactoryBot.create(:category,
+          parent_id: _1.id,
+          taxonomy: FactoryBot.create(:taxonomy, taxonomy: _1.taxonomy))
+      }
+    end
     let(:manager_category) { FactoryBot.create(:category, manager:) }
     let(:measure) { FactoryBot.create(:measure) }
     let(:recommendation) { FactoryBot.create(:recommendation) }
@@ -25,7 +32,7 @@ RSpec.describe ProgressReport, type: :model do
 
       measure.indicators << contributor_indicator
       recommendation.measures << measure
-      recommendation.categories += categories
+      recommendation.categories += child_categories
       recommendation.categories << manager_category
     end
 
@@ -35,6 +42,9 @@ RSpec.describe ProgressReport, type: :model do
 
     it "only sends updated emails to categories where the manager didn't make the change" do
       expect(ProgressReportMailer).not_to receive(:updated).with(subject, manager_category)
+      child_categories.each do |category|
+        expect(ProgressReportMailer).to receive(:updated).with(subject, category).and_return(double(deliver_now: true))
+      end
       categories.each do |category|
         expect(ProgressReportMailer).to receive(:updated).with(subject, category).and_return(double(deliver_now: true))
       end

--- a/spec/models/progress_report_spec.rb
+++ b/spec/models/progress_report_spec.rb
@@ -9,4 +9,37 @@ RSpec.describe ProgressReport, type: :model do
   it { is_expected.to have_many :categories }
   it { is_expected.to have_one :manager }
   it { is_expected.to validate_presence_of(:indicator_id) }
+
+  describe "#send_updated_emails" do
+    let(:categories) { FactoryBot.create_list(:category, 5) }
+    let(:manager_category) { FactoryBot.create(:category, manager:) }
+    let(:measure) { FactoryBot.create(:measure) }
+    let(:recommendation) { FactoryBot.create(:recommendation) }
+    let(:guest) { FactoryBot.create(:user) }
+    let(:manager) { FactoryBot.create(:user, :manager) }
+    let(:contributor) { FactoryBot.create(:user, :contributor) }
+    let(:contributor_indicator) { FactoryBot.create(:indicator, manager: contributor) }
+
+    before do
+      allow(::PaperTrail.request).to receive(:whodunnit).and_return(manager.id)
+
+      measure.indicators << contributor_indicator
+      recommendation.measures << measure
+      recommendation.categories += categories
+      recommendation.categories << manager_category
+    end
+
+    subject do
+      FactoryBot.create(:progress_report, indicator: contributor_indicator)
+    end
+
+    it "only sends updated emails to categories where the manager didn't make the change" do
+      expect(ProgressReportMailer).not_to receive(:updated).with(subject, manager_category)
+      categories.each do |category|
+        expect(ProgressReportMailer).to receive(:updated).with(subject, category).and_return(double(deliver_now: true))
+      end
+
+      subject.send_updated_emails
+    end
+  end
 end


### PR DESCRIPTION
Resolves #397 by sending an email to each category manager when a
progress report in their category is updated.