### PR TITLE
Add support_level integer to recommendations

### DIFF
--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -28,8 +28,8 @@ class Recommendation < VersionedRecord
   SUPPORT_LEVELS = {
     noted: 0,
     supported_in_part: 1,
-    supported: 2,
+    supported: 2
   }
   enum support_level: SUPPORT_LEVELS
-  validates :support_level, inclusion: { in: SUPPORT_LEVELS.keys }, unless: -> { support_level.blank? }
+  validates :support_level, inclusion: {in: SUPPORT_LEVELS.keys}, unless: -> { support_level.blank? }
 end

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -26,10 +26,25 @@ class Recommendation < VersionedRecord
   validates :reference, presence: true, uniqueness: true
 
   SUPPORT_LEVELS = {
-    noted: 0,
-    supported_in_part: 1,
-    supported: 2
+    "noted" => 0,
+    "supported_in_part" => 1,
+    "supported" => 2
   }
   enum support_level: SUPPORT_LEVELS
-  validates :support_level, inclusion: {in: SUPPORT_LEVELS.keys}, unless: -> { support_level.blank? }
+
+  # This approach prevents the validation process being aborted by an ArgumentError.
+  # Better enum validation exists in Rails 7.1 so we can replace this when we reach that version.
+  def support_level=(value)
+    if !SUPPORT_LEVELS.key?(value)
+      @invalid_support_level = true
+      return
+    end
+
+    super(value)
+  end
+  validate do
+    if @invalid_support_level
+      errors.add(:support_level, "is not a valid support_level. Valid options: #{SUPPORT_LEVELS.keys.join(", ")}")
+    end
+  end
 end

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -24,4 +24,12 @@ class Recommendation < VersionedRecord
 
   validates :title, presence: true
   validates :reference, presence: true, uniqueness: true
+
+  SUPPORT_LEVELS = {
+    noted: 0,
+    supported_in_part: 1,
+    supported: 2,
+  }
+  enum support_level: SUPPORT_LEVELS
+  validates :support_level, inclusion: { in: SUPPORT_LEVELS.keys }, unless: -> { support_level.blank? }
 end

--- a/app/policies/recommendation_policy.rb
+++ b/app/policies/recommendation_policy.rb
@@ -9,6 +9,7 @@ class RecommendationPolicy < ApplicationPolicy
       :reference,
       :description,
       :framework_id,
+      :support_level,
       recommendation_categories_attributes: [:category_id]]
   end
 

--- a/app/serializers/recommendation_serializer.rb
+++ b/app/serializers/recommendation_serializer.rb
@@ -1,7 +1,18 @@
 class RecommendationSerializer
   include FastVersionedSerializer
 
-  attributes :title, :accepted, :response, :draft, :reference, :description, :framework_id, :relationship_updated_at, :relationship_updated_by_id
+  attributes(
+    :title,
+    :accepted,
+    :response,
+    :draft,
+    :reference,
+    :description,
+    :framework_id,
+    :support_level,
+    :relationship_updated_at,
+    :relationship_updated_by_id
+  )
 
   set_type :recommendations
 end

--- a/db/migrate/20240726032048_add_support_level_to_recommendations.rb
+++ b/db/migrate/20240726032048_add_support_level_to_recommendations.rb
@@ -1,0 +1,5 @@
+class AddSupportLevelToRecommendations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :recommendations, :support_level, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_05_021300) do
+ActiveRecord::Schema.define(version: 2024_07_26_032048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -235,6 +235,7 @@ ActiveRecord::Schema.define(version: 2024_05_05_021300) do
     t.integer "updated_by_id"
     t.integer "framework_id"
     t.integer "created_by_id"
+    t.integer "support_level"
     t.bigint "relationship_updated_by_id"
     t.datetime "relationship_updated_at", precision: 6
     t.index ["draft"], name: "index_recommendations_on_draft"

--- a/spec/models/recommendation_spec.rb
+++ b/spec/models/recommendation_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Recommendation, type: :model do
     expect(FactoryBot.build(:recommendation, reference: "456")).to be_valid
   end
 
+  it do
+    is_expected.to(
+      define_enum_for(:support_level)
+        .with_values(Recommendation::SUPPORT_LEVELS.keys)
+        .backed_by_column_of_type(:integer)
+    )
+  end
+
   it { is_expected.to have_many :categories }
   it { is_expected.to have_many :measures }
   it { is_expected.to have_many :indicators }


### PR DESCRIPTION
### Context

https://github.com/impactoss/impactoss-server/issues/404

> Add integer field "support_level" to recommendations table and make
> available for the usual create, read and update operations.
>
> Background: this will eventually replace the boolean "accepted" field
> as the UN system is introducing a third response option. "Accepted"
> and "Noted" will be replaced with "Supported", "Supported in part" and
> "Noted" (which we will encode as 2, 1, and 0 - in addition we will
> have -1 or "null" for "not applicable")

### Changes

This commit adds a `support_level` field to the Recommendations table
with an enum-based value:

```ruby
{
  "noted" => 0,
  "supported_in_part" => 1,
  "supported" => 2
}
```

### Considerations

At this stage, the field is optional so we can use a null value to
to represent "not applicable". Once we have migrated across from the
boolean "accepted" field, we may want to consider making the field
mandatory and instead using a `-1` value for "not applicable".

Rails 7.1 allows enum fields to be validated without raising an error.
Since we're still using Rails 6, the Recommendation model checks for
invalid `support_level` assignment and convert it to a validation
failures so that we don't raise an `ArgumentError`.
