### PR TITLE
Make various reference and title fields mandatory

### DIFF
--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -2,7 +2,7 @@ class Indicator < VersionedRecord
   validates :title, presence: true
   validates :end_date, presence: true, if: :repeat?
   validates :frequency_months, presence: true, if: :repeat?
-  validates :reference, uniqueness: true
+  validates :reference, presence: true, uniqueness: true
   validate :end_date_after_start_date, if: :end_date?
 
   after_create :build_due_dates

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -20,7 +20,7 @@ class Measure < VersionedRecord
   accepts_nested_attributes_for :measure_categories
 
   validates :title, presence: true
-  validates :reference, uniqueness: true
+  validates :reference, presence: true, uniqueness: true
 
   def is_current
     recommendations.empty? || recommendations.any?(&:is_current)

--- a/db/migrate/20240910012254_make_reference_and_title_fields_mandatory.rb
+++ b/db/migrate/20240910012254_make_reference_and_title_fields_mandatory.rb
@@ -1,0 +1,9 @@
+class MakeReferenceAndTitleFieldsMandatory < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :measures, :reference, false, ""
+    change_column_null :indicators, :reference, false, ""
+    change_column_null :pages, :title, false, ""
+    change_column_null :categories, :title, false, ""
+    change_column_null :progress_reports, :title, false, ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_26_032048) do
+ActiveRecord::Schema.define(version: 2024_09_10_012254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2024_07_26_032048) do
   end
 
   create_table "categories", id: :serial, force: :cascade do |t|
-    t.text "title"
+    t.text "title", null: false
     t.string "short_title"
     t.text "description"
     t.string "url"
@@ -101,7 +101,7 @@ ActiveRecord::Schema.define(version: 2024_07_26_032048) do
     t.date "start_date"
     t.boolean "repeat", default: false
     t.date "end_date"
-    t.string "reference"
+    t.string "reference", null: false
     t.integer "updated_by_id"
     t.integer "created_by_id"
     t.datetime "relationship_updated_at", precision: 6
@@ -147,14 +147,14 @@ ActiveRecord::Schema.define(version: 2024_07_26_032048) do
     t.integer "created_by_id"
     t.datetime "relationship_updated_at", precision: 6
     t.bigint "relationship_updated_by_id"
-    t.string "reference"
+    t.string "reference", null: false
     t.boolean "is_archive", default: false, null: false
     t.index ["draft"], name: "index_measures_on_draft"
     t.index ["reference"], name: "index_measures_on_reference", unique: true
   end
 
   create_table "pages", id: :serial, force: :cascade do |t|
-    t.string "title"
+    t.string "title", null: false
     t.text "content"
     t.string "menu_title"
     t.boolean "draft", default: false
@@ -170,7 +170,7 @@ ActiveRecord::Schema.define(version: 2024_07_26_032048) do
   create_table "progress_reports", id: :serial, force: :cascade do |t|
     t.integer "indicator_id"
     t.integer "due_date_id"
-    t.text "title"
+    t.text "title", null: false
     t.text "description"
     t.string "document_url"
     t.boolean "document_public"

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -140,9 +140,10 @@ RSpec.describe IndicatorsController, type: :controller do
       let(:params) {
         {
           indicator: {
-            title: "test",
             description: "test",
-            target_date: "today"
+            reference: "test reference",
+            target_date: "today",
+            title: "test"
           }
         }
       }
@@ -167,10 +168,11 @@ RSpec.describe IndicatorsController, type: :controller do
         let(:params) {
           {
             indicator: {
-              title: "test",
               description: "test",
+              is_archive: true,
+              reference: "test reference",
               target_date: "today",
-              is_archive: true
+              title: "test"
             }
           }
         }
@@ -208,8 +210,15 @@ RSpec.describe IndicatorsController, type: :controller do
     subject do
       put :update,
         format: :json,
-        params: {id: indicator,
-                 indicator: {title: "test update", description: "test update", target_date: "today update"}}
+        params: {
+          id: indicator,
+          indicator: {
+            description: "test update",
+            reference: "test refrerence update",
+            target_date: "today update",
+            title: "test update"
+          }
+        }
     end
 
     context "when not signed in" do

--- a/spec/controllers/measures_controller_spec.rb
+++ b/spec/controllers/measures_controller_spec.rb
@@ -136,9 +136,10 @@ RSpec.describe MeasuresController, type: :controller do
       let(:params) {
         {
           measure: {
-            title: "test",
             description: "test",
-            target_date: "today"
+            reference: "test reference",
+            target_date: "today",
+            title: "test"
           }
         }
       }
@@ -177,10 +178,11 @@ RSpec.describe MeasuresController, type: :controller do
         let(:params) {
           {
             measure: {
-              title: "test",
               description: "test",
+              is_archive: true,
+              reference: "test reference",
               target_date: "today",
-              is_archive: true
+              title: "test"
             }
           }
         }
@@ -220,8 +222,15 @@ RSpec.describe MeasuresController, type: :controller do
     subject do
       put :update,
         format: :json,
-        params: {id: measure,
-                 measure: {title: "test update", description: "test update", target_date: "today update"}}
+        params: {
+          id: measure,
+          measure: {
+            title: "test update",
+            description: "test update",
+            reference: "test reference update",
+            target_date: "today update"
+          }
+        }
     end
 
     context "when not signed in" do

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Indicator, type: :model do
+  it { is_expected.to validate_presence_of :reference }
   it { is_expected.to validate_presence_of :title }
 
   it "validates uniqueness of reference" do

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Measure, type: :model do
+  it { is_expected.to validate_presence_of :reference }
   it { is_expected.to validate_presence_of :title }
 
   it "validates uniqueness of reference" do


### PR DESCRIPTION
### Context:

https://github.com/impactoss/impactoss-server/issues/403


### Changes:

This commit makes the following fields mandatory (table: field):

```
measures: reference
indicators: reference
pages: title
categories: title
progress_reports: title
```

It also updates the model validations and specs accordingly.


### Considerations:

The data migration sets any currently null values to `""` rather than
applying a more nuanced strategy. I'd like to confirm that this is okay
before we go ahead.
