### PR TITLE
Limit access to archived content like with drafts

### DIFF
--- a/app/policies/category_policy.rb
+++ b/app/policies/category_policy.rb
@@ -34,7 +34,7 @@ class CategoryPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
-      scope.where(draft: false)
+      scope.where(draft: false, is_archive: false)
     end
   end
 end

--- a/app/policies/indicator_policy.rb
+++ b/app/policies/indicator_policy.rb
@@ -31,7 +31,7 @@ class IndicatorPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
-      scope.where(draft: false)
+      scope.where(draft: false, is_archive: false)
     end
   end
 end

--- a/app/policies/measure_policy.rb
+++ b/app/policies/measure_policy.rb
@@ -43,7 +43,7 @@ class MeasurePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
-      scope.where(draft: false)
+      scope.where(draft: false, is_archive: false)
     end
   end
 end

--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -33,7 +33,7 @@ class PagePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
-      scope.where(draft: false)
+      scope.where(draft: false, is_archive: false)
     end
   end
 end

--- a/app/policies/progress_report_policy.rb
+++ b/app/policies/progress_report_policy.rb
@@ -29,7 +29,7 @@ class ProgressReportPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
-      scope.where(draft: false)
+      scope.where(draft: false, is_archive: false)
     end
   end
 end

--- a/app/policies/recommendation_policy.rb
+++ b/app/policies/recommendation_policy.rb
@@ -27,7 +27,7 @@ class RecommendationPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
-      scope.where(draft: false)
+      scope.where(draft: false, is_archive: false)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,9 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    # This option prevents RSpec from truncating output unless it's truly
+    # massive, as the default truncation often hides the reason for a failure.
+    expectations.max_formatted_output_length = 10000
   end
 
   # rspec-mocks config goes here. You can use an alternate test double


### PR DESCRIPTION
### Context

https://github.com/impactoss/impactoss-server/issues/409

We want archived content to only be visible to authenticated users with
the admin, manager, or contributor roles.

### Changes

This commit limits access to archived content in the same way that we
currently do for draft content.

It also makes various controller tests account for the new restriction,
upgrading them in the process.

### Considerations

Along the way, I found it helpful to change the RSpec setting that
limits the maximum formatted output length for any given test failure.
The default value was quite low, and RSpec truncated away a lot of
vital information when using the `match_array` matcher. I've included
that change in this commit.
