### PR TITLE
Use combined indicators for recommendations, categories, and their due dates

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -10,12 +10,6 @@ class Category < VersionedRecord
   has_many :recommendations, through: :recommendation_categories
   has_many :users, through: :user_categories
   has_many :measures, through: :measure_categories
-  has_many :indicators, through: :recommendations
-  has_many :indicators_via_measures, through: :recommendations
-  has_many :progress_reports, through: :indicators_via_measures
-  has_many :due_dates, -> { distinct }, through: :indicators_via_measures
-
-  has_many :children_due_dates, -> { distinct }, through: :categories, source: :due_dates
 
   delegate :name, :email, to: :manager, prefix: true, allow_nil: true
 
@@ -26,6 +20,17 @@ class Category < VersionedRecord
 
   scope :draft, -> { where(draft: true) }
   scope :published, -> { where(draft: false) }
+
+  def combined_indicator_ids
+    (
+      recommendations.flat_map(&:indicator_ids) +
+      categories.flat_map(&:combined_indicator_ids)
+    ).uniq
+  end
+
+  def due_dates
+    DueDate.where(indicator_id: combined_indicator_ids)
+  end
 
   def has_reporting_cycle_taxonomy?
     Taxonomy.current_reporting_cycle_id == taxonomy_id
@@ -86,18 +91,10 @@ class Category < VersionedRecord
     due_dates.are_due.each do |due_date|
       DueDateMailer.category_due(due_date, self).deliver_now
     end
-
-    children_due_dates.are_due.each do |due_date|
-      DueDateMailer.category_due(due_date, self).deliver_now
-    end
   end
 
   def send_overdue_emails
     due_dates.are_overdue.each do |due_date|
-      DueDateMailer.category_overdue(due_date, self).deliver_now
-    end
-
-    children_due_dates.are_overdue.each do |due_date|
       DueDateMailer.category_overdue(due_date, self).deliver_now
     end
   end

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -8,10 +8,25 @@ class Recommendation < VersionedRecord
 
   has_many :measures, through: :recommendation_measures
   has_many :categories, through: :recommendation_categories
-  has_many :indicators, through: :recommendation_indicators
+
+  has_many :indicators_direct, through: :recommendation_indicators, source: :indicator
   has_many :indicators_via_measures, through: :measures, source: :indicators
-  has_many :progress_reports, through: :indicators
-  has_many :due_dates, through: :indicators
+
+  def indicator_ids
+    (indicators_direct.pluck(:id) + indicators_via_measures.pluck(:id)).uniq
+  end
+
+  def indicators
+    Indicator.where(id: indicator_ids)
+  end
+
+  def due_dates
+    DueDate.where(indicator_id: indicator_ids)
+  end
+
+  def progress_reports
+    ProgressReport.where(indicator_id: indicator_ids)
+  end
 
   has_many :recommendation_recommendations, foreign_key: "recommendation_id"
   has_many :recommendations, through: :recommendation_recommendations, source: :other_recommendation

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -8,11 +8,7 @@ RSpec.describe Category, type: :model do
   it { is_expected.to have_many :recommendations }
   it { is_expected.to have_many :users }
   it { is_expected.to have_many :measures }
-  it { is_expected.to have_many :indicators }
-  it { is_expected.to have_many :progress_reports }
-  it { is_expected.to have_many :due_dates }
   it { is_expected.to have_many :categories }
-  it { is_expected.to have_many :children_due_dates }
 
   context "Sub-relation validations" do
     it "will not allow guest users to be assigned" do
@@ -83,6 +79,100 @@ RSpec.describe Category, type: :model do
       sub_category = FactoryBot.create(:category, :sub_category)
       sub_category.parent_id = category.id
       expect { sub_category.save! }.to raise_exception(/Validation failed: Parent Taxonomy does not have parent category's taxonomy as parent./)
+    end
+  end
+
+  describe "indicators" do
+    subject { FactoryBot.create(:category) }
+
+    let(:indicator_traits) { [] }
+
+    let(:child_taxonomy) { FactoryBot.create(:taxonomy, parent_id: subject.taxonomy.id) }
+    let(:child_category) { FactoryBot.create(:category, parent_id: subject.id, title: "Child Category", taxonomy: child_taxonomy) }
+
+    let(:first_recommendation) { FactoryBot.create(:recommendation, title: "First Recommendation") }
+    let(:second_recommendation) { FactoryBot.create(:recommendation, title: "Second Recommendation") }
+    let(:child_category_recommendation) { FactoryBot.create(:recommendation, title: "Child Category Recommendation") }
+
+    let(:first_direct_indicator) { FactoryBot.create(:indicator, *indicator_traits, title: "First Direct Indicator") }
+    let(:second_direct_indicator) { FactoryBot.create(:indicator, *indicator_traits, title: "Second Direct Indicator") }
+    let(:third_direct_indicator) { FactoryBot.create(:indicator, *indicator_traits, title: "Second Direct Indicator") }
+
+    let(:indicator_via_first_measure) { FactoryBot.create(:indicator, *indicator_traits, title: "Indicator via First Measure") }
+    let(:indicator_via_second_measure) { FactoryBot.create(:indicator, *indicator_traits, title: "Indicator via Second Measure") }
+
+    let(:first_shared_indicator) { FactoryBot.create(:indicator, *indicator_traits, title: "First Shared Indicator") }
+    let(:second_shared_indicator) { FactoryBot.create(:indicator, *indicator_traits, title: "Second Shared Indicator") }
+
+    let(:first_measure) { FactoryBot.create(:measure) }
+    let(:second_measure) { FactoryBot.create(:measure) }
+
+    let(:all_unique_indicators) do
+      [
+        first_direct_indicator,
+        second_direct_indicator,
+        third_direct_indicator,
+        indicator_via_first_measure,
+        indicator_via_second_measure,
+        first_shared_indicator,
+        second_shared_indicator
+      ]
+    end
+
+    before do
+      # Create direct indicators: two for the first recommendation, one for the second, and one for the child category recommendation
+      FactoryBot.create(:recommendation_indicator, recommendation: first_recommendation, indicator: first_direct_indicator)
+      FactoryBot.create(:recommendation_indicator, recommendation: first_recommendation, indicator: second_direct_indicator)
+
+      FactoryBot.create(:recommendation_indicator, recommendation: second_recommendation, indicator: second_direct_indicator)
+
+      FactoryBot.create(:recommendation_indicator, recommendation: child_category_recommendation, indicator: third_direct_indicator)
+
+      # Create indicators via measures
+      FactoryBot.create(:measure_indicator, measure: first_measure, indicator: indicator_via_first_measure)
+      FactoryBot.create(:measure_indicator, measure: second_measure, indicator: indicator_via_second_measure)
+
+      # Associate measures with the recommendation: one for the first recommendation, two for the second, and one for the child category recommendation
+      FactoryBot.create(:recommendation_measure, recommendation: first_recommendation, measure: first_measure)
+
+      FactoryBot.create(:recommendation_measure, recommendation: second_recommendation, measure: first_measure)
+      FactoryBot.create(:recommendation_measure, recommendation: second_recommendation, measure: second_measure)
+
+      FactoryBot.create(:recommendation_measure, recommendation: child_category_recommendation, measure: second_measure)
+
+      # Create shared indicators: both linked to every recommendation
+      FactoryBot.create(:measure_indicator, measure: first_measure, indicator: first_shared_indicator)
+      FactoryBot.create(:recommendation_indicator, recommendation: first_recommendation, indicator: first_shared_indicator)
+      FactoryBot.create(:recommendation_indicator, recommendation: second_recommendation, indicator: first_shared_indicator)
+      FactoryBot.create(:recommendation_indicator, recommendation: child_category_recommendation, indicator: first_shared_indicator)
+
+      FactoryBot.create(:measure_indicator, measure: second_measure, indicator: second_shared_indicator)
+      FactoryBot.create(:recommendation_indicator, recommendation: first_recommendation, indicator: second_shared_indicator)
+      FactoryBot.create(:recommendation_indicator, recommendation: second_recommendation, indicator: second_shared_indicator)
+      FactoryBot.create(:recommendation_indicator, recommendation: child_category_recommendation, indicator: second_shared_indicator)
+
+      # Associate recommendations to the category
+      FactoryBot.create(:recommendation_category, recommendation: first_recommendation, category: subject)
+      FactoryBot.create(:recommendation_category, recommendation: second_recommendation, category: subject)
+
+      # Associate child category
+      FactoryBot.create(:recommendation_category, recommendation: child_category_recommendation, category: child_category)
+    end
+
+    describe "#combined_indicator_ids" do
+      it "contains the IDs of all distinct indicators from recommendations and the recommendations of child categories" do
+        expect(subject.combined_indicator_ids).not_to be_empty
+        expect(subject.combined_indicator_ids).to match_array(all_unique_indicators.map(&:id))
+      end
+    end
+
+    describe "#due_dates" do
+      let(:indicator_traits) { [:with_12_due_dates] }
+
+      it "contains the due dates for all distinct indicators from recommendations and the recommendations of child categories" do
+        expect(subject.due_dates.to_a).not_to be_empty
+        expect(subject.due_dates.to_a).to match_array(all_unique_indicators.flat_map(&:due_dates))
+      end
     end
   end
 end

--- a/spec/models/recommendation_spec.rb
+++ b/spec/models/recommendation_spec.rb
@@ -15,9 +15,6 @@ RSpec.describe Recommendation, type: :model do
 
   it { is_expected.to have_many :categories }
   it { is_expected.to have_many :measures }
-  it { is_expected.to have_many :indicators }
-  it { is_expected.to have_many :progress_reports }
-  it { is_expected.to have_many :due_dates }
   it { is_expected.to have_many :recommendations }
   it { is_expected.to have_many :recommendation_recommendations }
   it { is_expected.to have_many :recommendation_categories }
@@ -70,6 +67,91 @@ RSpec.describe Recommendation, type: :model do
         allow(category).to receive(:is_current).and_return(false)
 
         expect(recommendation.is_current).to eq(true)
+      end
+    end
+  end
+
+  describe "indicators" do
+    subject { FactoryBot.create(:recommendation) }
+
+    let(:indicator_traits) {
+      []
+    }
+
+    let(:first_direct_indicator) { FactoryBot.create(:indicator, *indicator_traits, title: "First Direct Indicator") }
+    let(:second_direct_indicator) { FactoryBot.create(:indicator, *indicator_traits, title: "Second Direct Indicator") }
+
+    let(:indicator_via_first_measure) { FactoryBot.create(:indicator, *indicator_traits, title: "Indicator via First Measure") }
+    let(:indicator_via_second_measure) { FactoryBot.create(:indicator, *indicator_traits, title: "Indicator via Second Measure") }
+
+    let(:first_shared_indicator) { FactoryBot.create(:indicator, *indicator_traits, title: "First Shared Indicator") }
+    let(:second_shared_indicator) { FactoryBot.create(:indicator, *indicator_traits, title: "Second Shared Indicator") }
+
+    let(:first_measure) { FactoryBot.create(:measure) }
+    let(:second_measure) { FactoryBot.create(:measure) }
+
+    let(:all_unique_indicators) {
+      [
+        first_direct_indicator,
+        second_direct_indicator,
+        indicator_via_first_measure,
+        indicator_via_second_measure,
+        first_shared_indicator,
+        second_shared_indicator
+
+      ]
+    }
+
+    before do
+      # Create direct indicators
+      FactoryBot.create(:recommendation_indicator, recommendation: subject, indicator: first_direct_indicator)
+      FactoryBot.create(:recommendation_indicator, recommendation: subject, indicator: second_direct_indicator)
+
+      # Create indicators via measures
+      FactoryBot.create(:measure_indicator, measure: first_measure, indicator: indicator_via_first_measure)
+      FactoryBot.create(:measure_indicator, measure: second_measure, indicator: indicator_via_second_measure)
+
+      # Associate measures with the recommendation
+      FactoryBot.create(:recommendation_measure, recommendation: subject, measure: first_measure)
+      FactoryBot.create(:recommendation_measure, recommendation: subject, measure: second_measure)
+
+      # Create shared indicators
+      FactoryBot.create(:measure_indicator, measure: first_measure, indicator: first_shared_indicator)
+      FactoryBot.create(:recommendation_indicator, recommendation: subject, indicator: first_shared_indicator)
+      FactoryBot.create(:measure_indicator, measure: second_measure, indicator: second_shared_indicator)
+      FactoryBot.create(:recommendation_indicator, recommendation: subject, indicator: second_shared_indicator)
+    end
+
+    it "contains all distinct indicators from measures and recommendations" do
+      expect(subject.indicators.to_a).to match_array(all_unique_indicators)
+    end
+
+    describe "indicator_ids" do
+      it "contains all distinct indicator ids from measures and recommendations" do
+        expect(subject.indicator_ids).not_to be_empty
+        expect(subject.indicator_ids).to match_array(all_unique_indicators.map(&:id))
+      end
+    end
+
+    context "with due_dates" do
+      let(:indicator_traits) { [:with_12_due_dates] }
+
+      it "forwards the due_dates from the combined indicators" do
+        expect(subject.due_dates.to_a).not_to be_empty
+        expect(subject.due_dates.to_a).to match_array(subject.indicators.flat_map(&:due_dates))
+      end
+    end
+
+    context "with progress reports" do
+      before do
+        all_unique_indicators.each do |unique_indicator|
+          FactoryBot.create(:progress_report, indicator: unique_indicator)
+        end
+      end
+
+      it "forwards the progress reports from the combined indicators" do
+        expect(subject.progress_reports.to_a).not_to be_empty
+        expect(subject.progress_reports.to_a).to match_array(subject.indicators.flat_map(&:progress_reports))
       end
     end
   end


### PR DESCRIPTION
### Context

https://github.com/impactoss/impactoss-server/issues/385

When direct recommendation-indicator relationships were introduced, the
indirect relationships were initially lost. Those were needed to trigger
overdue emails to category managers.

We put a workaround in place in #386 but recognised the need for a
cleaner solution.

### Changes

This commit tidies up the way that we source indicators for
recommendations and subsequently for categories and their due dates.

### Considerations

Initially I tried to create an ActiveRecord `has_many` on Recommendation
that contained all of the indicators from both direct relations and
those from the measures. Unfortunately I wasn't successful in getting
that working; so far as I can tell it's not a supported behaviour.

Instead, I've used instance methods on the Category and Recommendation
models to build the collections that we need for our current features.
