### PR TITLE
Find and remove unused code using leftovers gem

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,0 +1,27 @@
+name: Analysis
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      max-parallel: 20
+    runs-on: ubuntu-latest
+
+    env:
+      CI: true
+      RAILS_ENV: test
+
+    name: leftovers
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - run: bin/leftovers

--- a/.leftovers_todo.yml
+++ b/.leftovers_todo.yml
@@ -1,0 +1,42 @@
+# for instructions on how to address these
+# see https://github.com/robotdana/leftovers/tree/v0.12.2/README.md#how-to-resolve
+
+keep:
+  # Policies are used by Pundit to determine what a user can and cannot do.
+  # Ideally we'd keep track of which policies are actually used, but we
+  # haven't figured out a way to do that yet.
+  - path: 'app/policies/*_policy.rb'
+    privacy: public
+    type: Method
+    names:
+      - create?
+      - destroy?
+      - edit?
+      - index?
+      - permitted_attributes
+      - resolve
+      - show?
+      - update?
+  - path: 'app/policies/*_policy.rb'
+    type: Constant
+    name:
+      - has_suffix: Policy
+
+  # Mailer previews are used to display emails in the browser.
+  # They're not used in production, but they're useful for development.
+  - path: 'spec/mailers/previews/*_preview.rb'
+    privacy: public
+    type: Constant
+    name:
+      - has_suffix: Preview
+
+dynamic:
+  # Nested associations are usually assigned in our controllers,
+  # but the process is often too indirect for leftovers to spot.
+  - path: 'app/models/*.rb'
+    name: accepts_nested_attributes_for
+    calls:
+      argument: '*'
+      transforms:
+        - add_suffix: '_attributes'
+        - add_suffix: '_attributes='

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem "factory_bot_rails", "~> 6.0"
   gem "faker"
   gem "i18n-tasks", "~> 0.9.6"
+  gem "leftovers", require: false
   gem "rspec-rails"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    fast_ignore (0.17.4)
     ffi (1.16.3)
     fog-aws (3.21.0)
       fog-core (~> 2.1)
@@ -202,6 +203,10 @@ GEM
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
+    leftovers (0.12.2)
+      fast_ignore (>= 0.17.0)
+      parallel
+      parser
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
     letter_opener_web (2.0.0)
@@ -479,6 +484,7 @@ DEPENDENCIES
   jsonapi-serializer
   kaminari
   launchy
+  leftovers
   letter_opener_web
   listen
   net-imap

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ApplicationCable
+module ApplicationCable # leftovers:keep
   class Channel < ActionCable::Channel::Base
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ApplicationCable
+module ApplicationCable # leftovers:keep
   class Connection < ActionCable::Connection::Base
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   before_action :set_paper_trail_whodunnit
 
   # Allow pundit to authorize a non-logged in user
-  def pundit_user
+  def pundit_user # leftovers:keep
     current_user || User.new
   end
 

--- a/app/controllers/impact_omniauth_callbacks_controller.rb
+++ b/app/controllers/impact_omniauth_callbacks_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class ImpactOmniauthCallbacksController < DeviseTokenAuth::OmniauthCallbacksController
+class ImpactOmniauthCallbacksController < DeviseTokenAuth::OmniauthCallbacksController # leftovers:keep
   def auth_hash
     @_auth_hash ||= request.env["omniauth.auth"] ||= session.delete("dta.omniauth.auth")
   end
 
-  def get_resource_from_auth_hash
+  def get_resource_from_auth_hash # leftovers:keep
     super
 
     if @resource

--- a/app/jobs/send_category_due_emails_job.rb
+++ b/app/jobs/send_category_due_emails_job.rb
@@ -1,4 +1,6 @@
-class SendCategoryDueEmailsJob < ApplicationJob
+# This is currently uncalled because it lacks an entry in Scheduler.rb
+# Maybe we can delete it?
+class SendCategoryDueEmailsJob < ApplicationJob # leftovers:keep
   queue_as :default
 
   def perform

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -8,7 +8,7 @@ class Category < VersionedRecord
   has_many :measure_categories, inverse_of: :category, dependent: :destroy
   has_many :sdgtarget_categories, inverse_of: :category, dependent: :destroy
   has_many :recommendations, through: :recommendation_categories
-  has_many :users, through: :user_categories
+  has_many :users, through: :user_categories # leftovers:keep
   has_many :measures, through: :measure_categories
   has_many :indicators, through: :recommendations
   has_many :indicators_via_measures, through: :recommendations

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -3,7 +3,7 @@ class Framework < ApplicationRecord
   has_many :frameworks, through: :framework_frameworks, source: :other_framework
 
   has_many :framework_taxonomies, inverse_of: :framework, dependent: :destroy
-  has_many :taxonomies, through: :framework_taxonomies
+  has_many :taxonomies, through: :framework_taxonomies # leftovers:keep
 
   has_many :recommendations
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,4 +1,4 @@
 class Role < ApplicationRecord
   has_many :user_roles
-  has_many :users, through: :user_roles
+  has_many :users, through: :user_roles # leftovers:keep
 end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -24,10 +24,6 @@ class Taxonomy < VersionedRecord
     end
   end
 
-  def self.current_reporting_cycle
-    find(current_reporting_cycle_id)
-  end
-
   def self.current_reporting_cycle_id
     Rails.application.config.x.reporting_cycle_taxonomy_id
   end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,7 +1,7 @@
 class Taxonomy < VersionedRecord
   has_many :categories
   belongs_to :taxonomy, class_name: "Taxonomy", foreign_key: :parent_id, optional: true
-  has_many :taxonomies, class_name: "Taxonomy", foreign_key: :parent_id
+  has_many :taxonomies, class_name: "Taxonomy", foreign_key: :parent_id # leftovers:keep
 
   has_many :framework_taxonomies, inverse_of: :taxonomy, dependent: :destroy
   has_many :frameworks, through: :framework_taxonomies

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,8 +11,8 @@ class User < VersionedRecord
 
   has_many :user_roles, dependent: :destroy
   has_many :roles, through: :user_roles
-  has_many :managed_categories, foreign_key: :manager_id, class_name: "Category"
-  has_many :managed_indicators, foreign_key: :manager_id, class_name: "Indicator"
+  has_many :managed_categories, foreign_key: :manager_id, class_name: "Category" # leftovers:keep
+  has_many :managed_indicators, foreign_key: :manager_id, class_name: "Indicator" # leftovers:keep
   has_many :user_categories
   has_many :categories, through: :user_categories
   has_many :bookmarks

--- a/app/serializers/fast_versioned_serializer.rb
+++ b/app/serializers/fast_versioned_serializer.rb
@@ -8,7 +8,8 @@ module FastVersionedSerializer
     base.attribute :updated_by_id # leftovers:keep
   end
 
-  def current_user_has_permission?
+  # This appears to be uncalled but I'm not 100% sure. Maybe we can delete it?
+  def current_user_has_permission? # leftovers:keep
     current_user&.role?("admin") || current_user&.role?("manager")
   end
 end

--- a/app/serializers/fast_versioned_serializer.rb
+++ b/app/serializers/fast_versioned_serializer.rb
@@ -4,8 +4,8 @@ module FastVersionedSerializer
   def self.included(base)
     base.include FastApplicationSerializer
 
-    base.attribute :created_by_id
-    base.attribute :updated_by_id
+    base.attribute :created_by_id # leftovers:keep
+    base.attribute :updated_by_id # leftovers:keep
   end
 
   def current_user_has_permission?

--- a/bin/leftovers
+++ b/bin/leftovers
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# The application 'leftovers' is installed as part of a gem, and
+# this file is here to facilitate running it.
+
+require "pathname"
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
+  Pathname.new(__FILE__).realpath)
+
+bundle_binstub = File.expand_path("../bundle", __FILE__)
+
+require "rubygems"
+require "bundler/setup"
+
+load Gem.bin_path("leftovers", "leftovers")

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module HumanRightsNationalReporting
+module HumanRightsNationalReporting # leftovers:keep
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1349,7 +1349,7 @@ class Seeds
     )
   end
 
-  def development_seeds!
+  def development_seeds! # leftovers:keep
     nil unless User.count.zero?
   end
 

--- a/scheduler.rb
+++ b/scheduler.rb
@@ -11,6 +11,8 @@ module Clockwork # leftovers:keep
     SendOverdueEmailsJob.perform_now
   end
 
+  # Should this also have a call to send Category Due Emails?
+
   every(1.day, "Send Category Overdue Emails", at: "9:15", tz: Rails.application.config.time_zone) do
     SendCategoryOverdueEmailsJob.perform_now
   end

--- a/scheduler.rb
+++ b/scheduler.rb
@@ -2,7 +2,7 @@ require File.expand_path("../config/boot", __FILE__)
 require File.expand_path("../config/environment", __FILE__)
 require "clockwork"
 
-module Clockwork
+module Clockwork # leftovers:keep
   every(1.day, "Send Due Emails", at: "10:30", tz: Rails.application.config.time_zone) do
     SendDueEmailsJob.perform_now
   end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -11,9 +11,4 @@ module ControllerMacros
     end
     user
   end
-
-  def sign_in_admin
-    user = sign_in
-    allow(user).to receive(:role?).with("admin").and_return(true)
-  end
 end

--- a/spec/support/feature_spec_helpers.rb
+++ b/spec/support/feature_spec_helpers.rb
@@ -1,5 +1,0 @@
-module FeatureSpecHelpers
-  def flash?(content)
-    page.has_css?(".callout", text: content)
-  end
-end


### PR DESCRIPTION
### Context

https://github.com/impactoss/impactoss-server/issues/363

We want to clean up the code base by removing unused code.

### Changes

This commit takes a first step at removing and preventing unused code by
installing the `leftovers` gem and running it as part of the build using
a new `Analysis` step. The gem uses static analysis to create a report
of all of the code that it thinks we haven't called. 

We can use the `.leftover_todo.yml` file to define general patterns for
the gem to either ignore (in the `keep` section) or consider to have
been dynamically executed (in the `dyanmic` section).

Where the gem finds individual lines of code that it thinks are not
called, but we are confident that we want to keep, we can annotate them
using `# leftovers:keep`. Examples of this are uncalled ActiveRecord
associations and methods that we need to define for gems to call.

In some cases, I was not sure if the code that leftovers reported was
safe to delete so I have annotated it and left comments to that effect.

In the future, we can use search for the `# leftovers:keep` annotation
when we're trying to figure out if something is safe to delete.

Finally, the commit removes some code that the gem reported as unused
and that I was confident enough to go ahead and delete.

### Considerations

The `leftovers` gem does not perform any kind of runtime logging to
identify which code paths are called (or not) on an ongoing basis.

Without that feature, it cannot report entirely vestigal features such
as groups of unused routes, controllers, models, and views.

For that task, we could either install a tool that performs runtime
logging or rely on our knowledge of the system and judge accordingly.

This commit does not fully address issue #363 because it does not delete
all of the code that we've identified and listed there. That work can be
completed as part of a future change.
