### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/impactoss/impactoss-server/security/code-scanning/2](https://github.com/impactoss/impactoss-server/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only appears to require read access to the repository contents (e.g., to check out the code), we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has the minimum permissions necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
