### PR TITLE
Invalidate other sessions on password change

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -46,4 +46,26 @@ class RegistrationsController < DeviseTokenAuth::RegistrationsController
   def destroy
     render json: {error: "Account deletion is not available"}, status: :forbidden
   end
+
+  ##
+  # On a password change, invalidate the user's other sessions by keeping only
+  # the token from the current request and dropping the rest.
+  #
+  # The slice runs before super because devise_token_auth prunes the tokens hash
+  # during the password-change save (inside update_with_password), so reshaping
+  # tokens here means that save persists just the current session. The current
+  # token's value is unchanged, so the browser stays authenticated without
+  # refreshed auth headers (which this controller skips via skip_after_action).
+  #
+  # Guarded on a password being present so that non-password account updates do
+  # not drop the user's other sessions. Only password changes reach this endpoint
+  # in normal app use (profile fields go through UsersController), so the guard is
+  # defensive - it keeps the invalidation tied strictly to password changes should
+  # another update ever be routed here.
+  def update
+    if @resource && @token && account_update_params[:password].present?
+      @resource.tokens = @resource.tokens.slice(@token.client)
+    end
+    super
+  end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -49,6 +49,17 @@ DeviseTokenAuth.setup do |config|
 
   # IMPORTANT: Disable bypass_sign_in for API-only mode (no sessions)
   config.bypass_sign_in = false
+
+  # When a user's password changes, drop all of their auth tokens except the one
+  # on the request that made the change, invalidating every other active session.
+  # Addresses pentest finding 3.2.1-C: without this, stock DTA leaves other tokens
+  # in place, so a hijacked session survives a legitimate password reset.
+  #
+  # Trigger is any encrypted_password change, not only the forgot-password flow —
+  # an in-app change or the password_expirable forced change clears other sessions
+  # too. The retained token is the newest by expiry, which in the reset flow is the
+  # session that completed the change.
+  config.remove_tokens_after_password_reset = true
 end
 
 # WORKAROUND: devise_token_auth 1.2.5+ (required for Rails 8) auto-adds :confirmable

--- a/spec/models/user_session_invalidation_on_password_change_spec.rb
+++ b/spec/models/user_session_invalidation_on_password_change_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# on password change, DTA's remove_tokens_after_password_reset
+# prunes users.tokens down to the session that completed the change, invalidating
+# every other (potentially hijacked) session. Enabled via
+#   config.remove_tokens_after_password_reset = true
+# in config/initializers/devise_token_auth.rb.
+#
+# The flag is deliberately NOT stubbed here: if it is ever turned off, the
+# keep-newest cases below fail, which is the regression signal we want. (With the
+# flag off, the two "unchanged / lone token" cases still pass, since they assert
+# no pruning; only the keep-newest and activity-projection cases flip.)
+#
+# Tokens are hand-built with explicit, distinct expiries so "newest" is
+# unambiguous — DTA compares the unix-timestamp expiry. Both are future-dated so
+# they survive destroy_expired_tokens, which runs as a before_save just ahead of
+# the prune.
+RSpec.describe User, "session invalidation on password change", type: :model do
+  let(:current_password) { "SecurePassword123!" }
+
+  # Must satisfy the app's secure_password validator and differ from
+  # current_password (password_archivable/deny_old_passwords rejects reuse).
+  # Adjust if the validator enforces rules beyond length/complexity.
+  let(:new_password) { "SecurePassword456!" }
+
+  let(:user) do
+    FactoryBot.create(:user, password: current_password, password_confirmation: current_password)
+  end
+
+  let(:older_client) { "older-client" }
+  let(:newer_client) { "newer-client" }
+
+  def token_entry(expiry)
+    {"token" => BCrypt::Password.create("t-#{expiry.to_i}"), "expiry" => expiry.to_i}
+  end
+
+  # Two live tokens with distinct future expiries. Saved without a password change
+  # so the prune does not fire during setup; reload returns the persisted
+  # (string-keyed) form and lets reconcile_token_activities seed the matching
+  # token_activities rows.
+  def seed_two_tokens!
+    user.tokens = {
+      older_client => token_entry(1.day.from_now),
+      newer_client => token_entry(3.days.from_now)
+    }
+    user.save!
+    user.reload
+  end
+
+  def change_password!
+    user.password = new_password
+    user.password_confirmation = new_password
+    user.save!
+    user.reload
+  end
+
+  it "keeps only the newest-expiry token and drops the rest" do
+    seed_two_tokens!
+    change_password!
+    expect(user.tokens.keys).to eq([newer_client])
+  end
+
+  it "leaves all tokens intact when the password is not changed" do
+    seed_two_tokens!
+
+    user.name = "Renamed Person"
+    user.save!
+    user.reload
+
+    expect(user.tokens.keys).to match_array([older_client, newer_client])
+  end
+
+  it "leaves a lone token untouched (nothing to prune)" do
+    solo_client = "solo-client"
+    user.tokens = {solo_client => token_entry(2.days.from_now)}
+    user.save!
+    user.reload
+
+    change_password!
+
+    expect(user.tokens.keys).to eq([solo_client])
+  end
+end

--- a/spec/requests/in_app_password_change_session_invalidation_spec.rb
+++ b/spec/requests/in_app_password_change_session_invalidation_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# In-app password change (PUT /auth) must invalidate the user's OTHER sessions
+# while keeping the session that made the change signed in. The controller keeps
+# only the current request's token and drops the rest before the change is
+# saved, so the surviving session is the one performing the change - not merely
+# the newest token by expiry.
+RSpec.describe "In-app password change session invalidation", type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:current_password) { "SecurePassword123!" }
+  let(:new_password) { "SecurePassword456!" }
+
+  let(:user) do
+    FactoryBot.create(:user, password: current_password, password_confirmation: current_password)
+  end
+
+  def auth_headers_from(source)
+    {
+      "access-token" => source["access-token"],
+      "client" => source["client"],
+      "uid" => source["uid"]
+    }
+  end
+
+  # MFA stubbed off so sign-in returns tokens directly, mirroring the
+  # session-timeout spec's helper. Each call is a fresh session for the user.
+  def sign_in_and_capture_headers
+    allow(Rails.application.config).to receive(:enable_mfa).and_return(false)
+    post "/auth/sign_in", params: {email: user.email, password: current_password}, as: :json
+    expect(response).to have_http_status(:success)
+    auth_headers_from(response.headers)
+  end
+
+  def change_password(headers)
+    put "/auth",
+      params: {
+        current_password: current_password,
+        password: new_password,
+        password_confirmation: new_password
+      },
+      headers: headers, as: :json
+  end
+
+  it "keeps the changing session and invalidates another session" do
+    changing_session = sign_in_and_capture_headers
+    other_session = sign_in_and_capture_headers
+
+    change_password(changing_session)
+    expect(response).to have_http_status(:success)
+
+    get "/bookmarks", headers: changing_session, as: :json
+    expect(response).to have_http_status(:success)
+
+    get "/bookmarks", headers: other_session, as: :json
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "keeps the changing session even when the other session is newer" do
+    changing_session = sign_in_and_capture_headers
+
+    # Sign the other session in later so its token expiry is strictly greater.
+    # Keeping the current session must not depend on expiry order: a plain
+    # keep-newest would retain this newer session and drop the one making the
+    # change.
+    travel 1.minute do
+      other_session = sign_in_and_capture_headers
+
+      change_password(changing_session)
+      expect(response).to have_http_status(:success)
+
+      get "/bookmarks", headers: changing_session, as: :json
+      expect(response).to have_http_status(:success)
+
+      get "/bookmarks", headers: other_session, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/in_app_password_change_session_invalidation_spec.rb
+++ b/spec/requests/in_app_password_change_session_invalidation_spec.rb
@@ -78,4 +78,24 @@ RSpec.describe "In-app password change session invalidation", type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
   end
+
+  # The controller reshapes @resource.tokens BEFORE super, so the invalidation is
+  # only ever persisted by the password-change save itself. A rejected change
+  # never saves, leaving the reshape in memory and the other sessions alive.
+  #
+  # That holds today because nothing else in the request saves @resource
+  # (update_auth_header is skipped on this controller). Pinned here because a
+  # future callback that does save would silently sign every other device out on
+  # a mistyped current password. 
+  it "does not invalidate other sessions when the change is rejected" do
+    changing_session = sign_in_and_capture_headers
+    other_session = sign_in_and_capture_headers
+
+    put "/auth", params: {current_password: "wrong", password: new_password,
+      password_confirmation: new_password}, headers: changing_session, as: :json
+    expect(response).to have_http_status(:unprocessable_content)
+
+    get "/bookmarks", headers: other_session, as: :json
+    expect(response).to have_http_status(:success)
+  end
 end

--- a/spec/requests/in_app_password_change_session_invalidation_spec.rb
+++ b/spec/requests/in_app_password_change_session_invalidation_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe "In-app password change session invalidation", type: :request do
   # That holds today because nothing else in the request saves @resource
   # (update_auth_header is skipped on this controller). Pinned here because a
   # future callback that does save would silently sign every other device out on
-  # a mistyped current password. 
+  # a mistyped current password.
   it "does not invalidate other sessions when the change is rejected" do
     changing_session = sign_in_and_capture_headers
     other_session = sign_in_and_capture_headers
 
     put "/auth", params: {current_password: "wrong", password: new_password,
-      password_confirmation: new_password}, headers: changing_session, as: :json
+                          password_confirmation: new_password}, headers: changing_session, as: :json
     expect(response).to have_http_status(:unprocessable_content)
 
     get "/bookmarks", headers: other_session, as: :json

--- a/spec/requests/password_reset_session_invalidation_spec.rb
+++ b/spec/requests/password_reset_session_invalidation_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# driving a real password reset through the DTA
+# endpoints must leave the session that COMPLETED the reset usable while
+# invalidating a pre-existing (potentially hijacked) session.
+#
+# The model spec covers the prune logic in isolation; this covers the actual
+# reset route - the PasswordsController subclass gate plus the edit -> update
+# flow that mints the completing session's token. Scope is deliberately narrow:
+# it asserts only the invalidation outcome (old token dead, completing token
+# alive), not DTA's reset mechanics.
+#
+# Relies on config.remove_tokens_after_password_reset = true, and on token
+# rotation being off (change_headers_on_each_request = false) so the completing
+# session's headers stay valid after the update.
+RSpec.describe "Password reset session invalidation", type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:current_password) { "SecurePassword123!" }
+  let(:new_password) { "SecurePassword456!" }
+  let(:redirect_url) { "http://localhost" } # host allowed by redirect_options
+
+  let(:user) do
+    FactoryBot.create(:user, password: current_password, password_confirmation: current_password)
+  end
+
+  def auth_headers_from(source)
+    {
+      "access-token" => source["access-token"],
+      "client" => source["client"],
+      "uid" => source["uid"]
+    }
+  end
+
+  # A real pre-existing session (the one that should be invalidated). MFA is
+  # stubbed off so sign-in returns tokens directly, mirroring the session-timeout
+  # spec's helper.
+  def sign_in_and_capture_headers
+    allow(Rails.application.config).to receive(:enable_mfa).and_return(false)
+    post "/auth/sign_in", params: {email: user.email, password: current_password}, as: :json
+    expect(response).to have_http_status(:success)
+    auth_headers_from(response.headers)
+  end
+
+  it "invalidates a pre-existing session and keeps the reset-completing session" do
+    old_session = sign_in_and_capture_headers
+
+    # remove_tokens_after_password_reset keeps max_by(expiry), and expiry has
+    # per-second granularity. In production the reset happens meaningfully later
+    # than the pre-existing sign-in, so the completing token's expiry is strictly
+    # greater and it is the one retained. Advance the clock so that holds here
+    # too: without a gap both tokens land in the same expiry second and the tie
+    # resolves to the OLDER (first-inserted) token, dropping the wrong session.
+    travel 1.minute do
+      # Seed the reset directly: returns the raw token, sets reset_password_sent_at,
+      # sends no mail. Keeps the test off the mailer and focused on invalidation
+      # rather than re-testing the /auth/password create endpoint.
+      raw_reset_token = user.reload.send(:set_reset_password_token)
+
+      # edit mints the completing session's token and sets allow_password_change;
+      # the token is handed back in the redirect URL (query, or fragment on some
+      # DTA paths - handle both).
+      get "/auth/password/edit", params: {reset_password_token: raw_reset_token, redirect_url: redirect_url}
+      expect(response).to have_http_status(:redirect)
+      location = URI.parse(response.location)
+      completing_session = auth_headers_from(Rack::Utils.parse_query(location.query || location.fragment))
+
+      # Complete the reset, authenticated as the completing session.
+      put "/auth/password",
+        params: {password: new_password, password_confirmation: new_password},
+        headers: completing_session, as: :json
+      expect(response).to have_http_status(:success)
+
+      # Old session is now dead...
+      get "/bookmarks", headers: old_session, as: :json
+      expect(response).to have_http_status(:unauthorized)
+
+      # ...and the reset-completing session still works.
+      get "/bookmarks", headers: completing_session, as: :json
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
Invalidates a user's other sessions when their password changes, so a compromised session does not survive a reset.

Two paths are covered:

- Password reset (`/auth/password`): enables devise_token_auth's `remove_tokens_after_password_reset`, which prunes the tokens hash to the session completing the reset. `edit` mints that session's token last, so it is the one retained.
- In-app password change (`PUT /auth`): `RegistrationsController#update` slices the tokens hash to the current request's token before the change is saved. This keeps the session performing the change regardless of token expiry order, and drops the rest. Needed because keep-newest alone would retain whichever session was newest, which on the in-app path is not necessarily the one making the change.

The in-app slice keeps the current token's value unchanged, so the browser stays authenticated without refreshed auth headers.

Specs: model-level prune behaviour, request-level reset invalidation, and request-level in-app invalidation (including the case where the other session is newer). Verified on UAT for both paths and both session orderings.

Related: #508 closes an unintended password-change path on
`PUT /users/{id}`; the single-password-path assumption here depends on it.