### PR TITLE
Restrict user update attributes

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -36,14 +36,10 @@ class UserPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    attrs = [
-      :name,
-      :password,
-      :password_confirmation
-    ]
+    attrs = [:name]
 
     # Email always allowed on creation, for updates depending on config
-    attrs << :email if @record.new_record? || allowed_roles_for(:update_email) == true
+    attrs << :email if allowed_roles_for(:update_email) == true
 
     attrs.compact
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -41,7 +41,7 @@ class UserPolicy < ApplicationPolicy
     # Email always allowed on creation, for updates depending on config
     attrs << :email if allowed_roles_for(:update_email) == true
 
-    attrs.compact
+    attrs
   end
 
   def show_email?

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -255,6 +255,43 @@ RSpec.describe UsersController, type: :controller do
           end
         end
       end
+
+      context "change password attribute" do
+        let(:target_user) { FactoryBot.create(:user, :contributor) }
+        let(:original_password) { target_user.password }
+
+        it "ignores a password in the update (admin cannot set another user's password)" do
+          admin = FactoryBot.create(:user, :admin)
+          sign_in admin
+
+          response = put :update, format: :json, params: {
+            id: target_user.id,
+            user: {name: "New Name", password: "AttackerSetPass123!"}
+          }
+
+          expect(response).to be_ok
+          expect(target_user.reload.name).to eq("New Name")
+          # Password param is stripped by the policy, so the change is a no-op:
+          # the original password still authenticates, the attempted one does not.
+          expect(target_user.reload.valid_password?(original_password)).to be(true)
+          expect(target_user.reload.valid_password?("AttackerSetPass123!")).to be(false)
+        end
+
+        it "ignores a password in a self-update" do
+          user = FactoryBot.create(:user, :admin)
+          sign_in user
+          original = user.password
+
+          response = put :update, format: :json, params: {
+            id: user.id,
+            user: {name: "Self Renamed", password: "SelfSetPass123!"}
+          }
+
+          expect(response).to be_ok
+          expect(user.reload.valid_password?(original)).to be(true)
+          expect(user.reload.valid_password?("SelfSetPass123!")).to be(false)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Removes `password` / `password_confirmation` from `UserPolicy`'s permitted attributes, closing an unintended password-change path via `PUT /users/{id}`.

These attributes were permitted on updates (not gated on `new_record?` the way `email` is), so an admin or manager could set another user's password through the users endpoint, and a user could set their own there. Neither is a path the app uses - registration and password change both go through `/auth`. Password params sent to `/users/{id}` are now silently stripped.

Also trims the dead `@record.new_record?` branch from the email line (this path only handles persisted records) and updates the stale comment.

Specs: `PUT /users/{id}` with a password is a no-op for both an admin updating another user and a self-update - the name change applies, the password does not, and the original password still authenticates.

Related: #507. That change makes `/auth` the sole password-change path; this PR closes the alternative.