### PR TITLE
Notify users by email on password change

### DIFF
--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,5 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t(:hello).capitalize %> <%= @resource.email %>!</p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p><%= t '.password_changed_msg' %></p>
+
+<p><%= t '.no_change_warning_msg' %></p>

--- a/app/views/devise/mailer/password_change.text.erb
+++ b/app/views/devise/mailer/password_change.text.erb
@@ -1,0 +1,5 @@
+<%= t(:hello).capitalize %> <%= @resource.email %>!
+
+<%= t '.password_changed_msg' %>
+
+<%= t '.no_change_warning_msg' %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -112,7 +112,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 11
 
   # Send a notification email when the user's password is changed
-  # config.send_password_change_notification = false
+  config.send_password_change_notification = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -41,6 +41,10 @@ en:
         unlock_link: "Unlock my account"
       password_change:
         subject: "Password Changed"
+        password_changed_msg: "We're contacting you to confirm that your password has been changed."
+        no_change_warning_msg: >
+          If you did not make this change, your account may be compromised. Please
+          reset your password immediately and contact your administrator.
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -40,7 +40,7 @@ en:
         unlock_link_msg: "Click the link below to unlock your account:"
         unlock_link: "Unlock my account"
       password_change:
-        subject: "Password Changed"
+        subject: "Password changed"
         password_changed_msg: "We're contacting you to confirm that your password has been changed."
         no_change_warning_msg: >
           If you did not make this change, your account may be compromised. Please

--- a/spec/models/user_password_change_notification_spec.rb
+++ b/spec/models/user_password_change_notification_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Devise fires a password-change notification via an after_update on the user,
+# gated on the encrypted password actually changing
+# (config.send_password_change_notification). This pins that trigger: the
+# notification mailer is invoked once on a password change and not on other
+# updates.
+#
+# The mailer is stubbed (returning a delivery double) rather than rendered, so
+# this asserts the trigger, not the email's content or delivery. Real rendering
+# and delivery are covered on UAT.
+RSpec.describe User, "password change notification", type: :model do
+  let(:current_password) { "SecurePassword123!" }
+  let(:new_password) { "SecurePassword456!" }
+
+  let(:user) do
+    FactoryBot.create(:user, password: current_password, password_confirmation: current_password)
+  end
+
+  # deliver / deliver_now both covered so this doesn't depend on which Devise
+  # uses to send; with(user, any_args) tolerates the trailing opts hash.
+  def stub_password_change_mail
+    double(deliver: true, deliver_now: true)
+  end
+
+  it "sends a password-change notification when the password changes" do
+    expect(CustomDeviseMailer).to receive(:password_change)
+      .with(user, any_args).and_return(stub_password_change_mail)
+
+    user.update!(password: new_password, password_confirmation: new_password)
+  end
+
+  it "does not send one on a non-password update" do
+    expect(CustomDeviseMailer).not_to receive(:password_change)
+
+    user.update!(name: "Renamed Person")
+  end
+
+  it "sends only once when a follow-up save leaves the password unchanged" do
+    # Mirrors the reset flow, where the password-change save is followed by a
+    # second save (setting allow_password_change = false) that must not re-notify.
+    expect(CustomDeviseMailer).to receive(:password_change)
+      .with(user, any_args).once.and_return(stub_password_change_mail)
+
+    user.update!(password: new_password, password_confirmation: new_password)
+    user.update!(name: "Renamed Person")
+  end
+end


### PR DESCRIPTION
Enables config.send_password_change_notification, so both password change paths (in-app change and reset) email the account holder when their password changes. Fires from Devise's after_update on the user, so no controller changes are needed; verified neither path suppresses it.

Adds the password_change mailer templates (html + text) and locale keys, matching the reset-instructions email style. The "wasn't you" line is worded as a call to action, since the change has already happened.

Spec asserts the trigger (mailer invoked once on a password change, not on other updates); rendering/delivery verified on UAT.