### PR TITLE
Redirect invalid reset links instead of raising 500

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -25,4 +25,15 @@ class PasswordsController < DeviseTokenAuth::PasswordsController
     end
     super
   end
+
+  # Stock DTA raises ActionController::RoutingError on an invalid or expired
+  # reset token, which surfaces as a 500 in this API-only app. Redirect the
+  # browser to the client's link-expired page instead, so a dead link lands on a
+  # real page rather than an error.
+  def render_edit_error
+    redirect_to(
+      File.join(ENV.fetch("CLIENT_URL"), ENV.fetch("CLIENT_RESET_LINK_INVALID_PATH", "not-found")),
+      allow_other_host: true
+    )
+  end
 end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -32,7 +32,7 @@ class PasswordsController < DeviseTokenAuth::PasswordsController
   # real page rather than an error.
   def render_edit_error
     redirect_to(
-      File.join(ENV.fetch("CLIENT_URL"), ENV.fetch("CLIENT_RESET_LINK_INVALID_PATH", "not-found")),
+      File.join(ENV.fetch("CLIENT_URL", "https://undefined.client.url"), ENV.fetch("CLIENT_RESET_LINK_INVALID_PATH", "not-found")),
       allow_other_host: true
     )
   end

--- a/spec/requests/reset_link_invalid_spec.rb
+++ b/spec/requests/reset_link_invalid_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "GET /auth/password/edit", type: :request do
+  before { allow(ENV).to receive(:fetch).and_call_original }
+
+  it "redirects an invalid reset token to the configured invalid-link page" do
+    allow(ENV).to receive(:fetch).with("CLIENT_URL").and_return("https://example.com")
+    allow(ENV).to receive(:fetch).with("CLIENT_RESET_LINK_INVALID_PATH", "not-found").and_return("reset-link-invalid")
+
+    get "/auth/password/edit", params: {
+      reset_password_token: "invalid",
+      redirect_url: "https://example.com"
+    }
+
+    expect(response).to redirect_to("https://example.com/reset-link-invalid")
+  end
+
+  it "falls back to the default path when the var is unset" do
+    allow(ENV).to receive(:fetch).with("CLIENT_URL").and_return("https://example.com")
+
+    get "/auth/password/edit", params: {
+      reset_password_token: "invalid",
+      redirect_url: "https://example.com"
+    }
+    expect(response).to redirect_to("https://example.com/not-found")
+  end
+end

--- a/spec/requests/reset_link_invalid_spec.rb
+++ b/spec/requests/reset_link_invalid_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "GET /auth/password/edit", type: :request do
   before { allow(ENV).to receive(:fetch).and_call_original }
 
   it "redirects an invalid reset token to the configured invalid-link page" do
-    allow(ENV).to receive(:fetch).with("CLIENT_URL").and_return("https://example.com")
+    allow(ENV).to receive(:fetch).with("CLIENT_URL", anything).and_return("https://example.com")
     allow(ENV).to receive(:fetch).with("CLIENT_RESET_LINK_INVALID_PATH", "not-found").and_return("reset-link-invalid")
 
     get "/auth/password/edit", params: {
@@ -16,7 +16,7 @@ RSpec.describe "GET /auth/password/edit", type: :request do
   end
 
   it "falls back to the default path when the var is unset" do
-    allow(ENV).to receive(:fetch).with("CLIENT_URL").and_return("https://example.com")
+    allow(ENV).to receive(:fetch).with("CLIENT_URL", anything).and_return("https://example.com")
 
     get "/auth/password/edit", params: {
       reset_password_token: "invalid",


### PR DESCRIPTION
Stock devise_token_auth raises ActionController::RoutingError on an invalid or expired password reset token, which surfaces as an HTTP 500 in this API-only app and leaves the user on a blank/home page.

Overrides render_edit_error in PasswordsController to redirect the browser to CLIENT_URL + CLIENT_RESET_LINK_INVALID_PATH (default: not-found) instead of raising. Fires for all dead-link cases (expired, malformed, not-found, already-used), so a bad link lands on a real page rather than an error. Still need to create link-invalid page/route in client

Fixes both the 500 and the silent home-page redirect.

Verified on UAT: an invalid reset link now redirects to CLIENT_RESET_LINK_INVALID_PATH (or fallback) and renders the client "Page not found" page. Spec covers the configured path and the default fallback.