### PR TITLE
Require current password for sensitive user changes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,4 +84,17 @@ class ApplicationController < ActionController::API
   def skip_authentication?
     devise_or_devise_token_auth_controller? || action_name == "index"
   end
+
+  # Re-authentication gate for sensitive actions. The client always sends
+  # current_password on these requests, so this only rejects direct API calls
+  # (e.g. a hijacked session attempting a sensitive change).
+  def require_current_password!
+    password = params[:current_password]
+    unless password.present? && current_user&.valid_password?(password)
+      render json: {
+        status: "error",
+        errors: {current_password: ["is incorrect or missing"]}
+      }, status: :unauthorized
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,11 +90,12 @@ class ApplicationController < ActionController::API
   # (e.g. a hijacked session attempting a sensitive change).
   def require_current_password!
     password = params[:current_password]
-    unless password.present? && current_user&.valid_password?(password)
-      render json: {
-        status: "error",
-        errors: {current_password: ["is incorrect or missing"]}
-      }, status: :unauthorized
-    end
+    return true if password.present? && current_user&.valid_password?(password)
+
+    render json: {
+      status: "error",
+      errors: {current_password: ["is incorrect or missing"]}
+    }, status: :unauthorized
+    false
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,7 +94,7 @@ class ApplicationController < ActionController::API
   # Warden after_set_user hook, which does not fire on this path.
   #
   def require_current_password!
-    password = params[:current_password]
+    password = request.request_parameters[:current_password]
 
     if password.present? &&
         current_user&.valid_for_authentication? { current_user.valid_password?(password) }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,24 @@ class ApplicationController < ActionController::API
     devise_or_devise_token_auth_controller? || action_name == "index"
   end
 
-  # Re-authentication gate for sensitive actions. The client always sends
-  # current_password on these requests, so this only rejects direct API calls
-  # (e.g. a hijacked session attempting a sensitive change).
+  # Re-authentication gate for sensitive actions (role and email changes).
+  # Routed through Devise's valid_for_authentication? so failures count toward
+  # :lockable - a bare valid_password? here would be an unthrottled password
+  # oracle, usable even while the account is locked out of sign-in.
+  #
+  # Success resets failed_attempts explicitly: Devise normally does that in a
+  # Warden after_set_user hook, which does not fire on this path.
+  #
   def require_current_password!
     password = params[:current_password]
-    return true if password.present? && current_user&.valid_password?(password)
+
+    if password.present? &&
+        current_user&.valid_for_authentication? { current_user.valid_password?(password) }
+      if current_user.failed_attempts.to_i.positive?
+        current_user.update_column(:failed_attempts, 0)
+      end
+      return true
+    end
 
     render json: {
       status: "error",

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,6 +1,6 @@
 class UserRolesController < ApplicationController
-  before_action :require_current_password!, only: [:create, :destroy]
   before_action :set_and_authorize_user_role, only: [:destroy]
+  before_action :require_current_password!, only: [:destroy]
 
   # GET /user_roles
   def index
@@ -15,6 +15,7 @@ class UserRolesController < ApplicationController
     @user_role = UserRole.new
     @user_role.assign_attributes(permitted_attributes(@user_role))
     authorize @user_role
+    return unless require_current_password!
 
     if @user_role.save
       render json: serialize(@user_role), status: :created, location: @user_role

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -1,4 +1,5 @@
 class UserRolesController < ApplicationController
+  before_action :require_current_password!, only: [:create, :destroy]
   before_action :set_and_authorize_user_role, only: [:destroy]
 
   # GET /user_roles

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-
   before_action :set_and_authorize_user, only: [:update]
+  before_action :require_current_password!, only: [:update], if: :email_change_requested?
 
   # GET /users
   def index
@@ -40,5 +40,10 @@ class UsersController < ApplicationController
   def set_and_authorize_user
     @user = policy_scope(base_object).find(params[:id])
     authorize @user
+  end
+
+  def email_change_requested?
+    new_email = permitted_attributes(@user)[:email]
+    new_email.present? && new_email != @user.email
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -36,14 +36,10 @@ class UserPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    attrs = [
-      :name,
-      :password,
-      :password_confirmation
-    ]
+    attrs = [:name]
 
     # Email always allowed on creation, for updates depending on config
-    attrs << :email if @record.new_record? || allowed_roles_for(:update_email) == true
+    attrs << :email if allowed_roles_for(:update_email) == true
 
     attrs.compact
   end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -29,7 +29,7 @@ DeviseTokenAuth.setup do |config|
   # Uncomment to enforce current_password param to be checked before all
   # attribute updates. Set it to :password if you want it to be checked only if
   # password is updated.
-  # config.check_current_password_before_update = :attributes
+  config.check_current_password_before_update = :password
 
   # By default we will use callbacks for single omniauth.
   # It depends on fields like email, provider and uid.

--- a/spec/controllers/user_roles_controller_spec.rb
+++ b/spec/controllers/user_roles_controller_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 require "json"
 
 RSpec.describe UserRolesController, type: :controller do
+  let(:current_password) { "SecurePassword123!" }
+
   describe "Get index" do
     subject { get :index, format: :json }
 
@@ -127,6 +129,7 @@ RSpec.describe UserRolesController, type: :controller do
               sign_in user
 
               response = post :create, format: :json, params: {
+                current_password: CURRENT_PASSWORD,
                 user_role: {
                   user_id: target_user.id,
                   role_id: target_role_record.id
@@ -156,6 +159,7 @@ RSpec.describe UserRolesController, type: :controller do
                 sign_in user
 
                 response = post :create, format: :json, params: {
+                  current_password: CURRENT_PASSWORD,
                   user_role: {
                     user_id: target_user.id,
                     role_id: target_role_record.id
@@ -196,6 +200,7 @@ RSpec.describe UserRolesController, type: :controller do
         admin = FactoryBot.create(:user, :admin)
         sign_in admin
         post :create, format: :json, params: {
+          current_password: CURRENT_PASSWORD,
           user_role: {description: "desc only", taxonomy_id: 999}
         }
         expect(response).to have_http_status(422)
@@ -207,6 +212,7 @@ RSpec.describe UserRolesController, type: :controller do
         sign_in admin
 
         response = post :create, format: :json, params: {
+          current_password: CURRENT_PASSWORD,
           user_role: {
             user_id: guest.id,
             role_id: admin_role.id
@@ -262,6 +268,7 @@ RSpec.describe UserRolesController, type: :controller do
               sign_in user
 
               response = delete :destroy, format: :json, params: {
+                current_password: CURRENT_PASSWORD,
                 id: target_user.user_roles.first.id
               }
               expect(response).to be_no_content
@@ -288,6 +295,7 @@ RSpec.describe UserRolesController, type: :controller do
                 sign_in user
 
                 response = delete :destroy, format: :json, params: {
+                  current_password: CURRENT_PASSWORD,
                   id: target_user.user_roles.first.id
                 }
                 expect(response).to be_no_content

--- a/spec/controllers/user_roles_controller_spec.rb
+++ b/spec/controllers/user_roles_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe UserRolesController, type: :controller do
               sign_in user
 
               response = post :create, format: :json, params: {
-                current_password: CURRENT_PASSWORD,
+                current_password: current_password,
                 user_role: {
                   user_id: target_user.id,
                   role_id: target_role_record.id
@@ -159,7 +159,7 @@ RSpec.describe UserRolesController, type: :controller do
                 sign_in user
 
                 response = post :create, format: :json, params: {
-                  current_password: CURRENT_PASSWORD,
+                  current_password: current_password,
                   user_role: {
                     user_id: target_user.id,
                     role_id: target_role_record.id
@@ -200,7 +200,7 @@ RSpec.describe UserRolesController, type: :controller do
         admin = FactoryBot.create(:user, :admin)
         sign_in admin
         post :create, format: :json, params: {
-          current_password: CURRENT_PASSWORD,
+          current_password: current_password,
           user_role: {description: "desc only", taxonomy_id: 999}
         }
         expect(response).to have_http_status(422)
@@ -212,7 +212,7 @@ RSpec.describe UserRolesController, type: :controller do
         sign_in admin
 
         response = post :create, format: :json, params: {
-          current_password: CURRENT_PASSWORD,
+          current_password: current_password,
           user_role: {
             user_id: guest.id,
             role_id: admin_role.id
@@ -268,7 +268,7 @@ RSpec.describe UserRolesController, type: :controller do
               sign_in user
 
               response = delete :destroy, format: :json, params: {
-                current_password: CURRENT_PASSWORD,
+                current_password: current_password,
                 id: target_user.user_roles.first.id
               }
               expect(response).to be_no_content
@@ -295,7 +295,7 @@ RSpec.describe UserRolesController, type: :controller do
                 sign_in user
 
                 response = delete :destroy, format: :json, params: {
-                  current_password: CURRENT_PASSWORD,
+                  current_password: current_password,
                   id: target_user.user_roles.first.id
                 }
                 expect(response).to be_no_content

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -255,6 +255,43 @@ RSpec.describe UsersController, type: :controller do
           end
         end
       end
+
+      context "change password attribute" do
+        let(:target_user) { FactoryBot.create(:user, :contributor) }
+        let(:original_password) { target_user.password }
+
+        it "ignores a password in the update (admin cannot set another user's password)" do
+          admin = FactoryBot.create(:user, :admin)
+          sign_in admin
+
+          response = put :update, format: :json, params: {
+            id: target_user.id,
+            user: {name: "New Name", password: "AttackerSetPass123!"}
+          }
+
+          expect(response).to be_ok
+          expect(target_user.reload.name).to eq("New Name")
+          # Password param is stripped by the policy, so the change is a no-op:
+          # the original password still authenticates, the attempted one does not.
+          expect(target_user.reload.valid_password?(original_password)).to be(true)
+          expect(target_user.reload.valid_password?("AttackerSetPass123!")).to be(false)
+        end
+
+        it "ignores a password in a self-update" do
+          user = FactoryBot.create(:user, :admin)
+          sign_in user
+          original = user.password
+
+          response = put :update, format: :json, params: {
+            id: user.id,
+            user: {name: "Self Renamed", password: "SelfSetPass123!"}
+          }
+
+          expect(response).to be_ok
+          expect(user.reload.valid_password?(original)).to be(true)
+          expect(user.reload.valid_password?("SelfSetPass123!")).to be(false)
+        end
+      end
     end
   end
 end

--- a/spec/requests/current_password_gate_throttling_spec.rb
+++ b/spec/requests/current_password_gate_throttling_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The re-authentication gate (ApplicationController#require_current_password!)
+# routes failures through Devise's valid_for_authentication?, so a wrong
+# current_password counts toward :lockable. Without that it would be an
+# unthrottled password oracle, usable even while the account is locked out of
+# sign-in. Exercised here via POST /user_roles; the gate is shared with
+# UsersController#update.
+RSpec.describe "Current password gate throttling", type: :request do
+  let(:password) { "SecurePassword123!" }
+  let(:admin) { FactoryBot.create(:user, :admin, password:, password_confirmation: password) }
+  let(:target) { FactoryBot.create(:user) }
+  let(:role) { FactoryBot.create(:role, :contributor) }
+
+  def sign_in_headers
+    allow(Rails.application.config).to receive(:enable_mfa).and_return(false)
+    post "/auth/sign_in", params: {email: admin.email, password:}, as: :json
+    expect(response).to have_http_status(:success)
+    {
+      "access-token" => response.headers["access-token"],
+      "client" => response.headers["client"],
+      "uid" => response.headers["uid"]
+    }
+  end
+
+  # Signed in once, then reused: a fresh sign-in would reset failed_attempts
+  # via Warden's after_set_user hook and mask the counting under test.
+  let!(:headers) { sign_in_headers }
+
+  def attempt(current_password)
+    post "/user_roles",
+      params: {current_password:, user_role: {user_id: target.id, role_id: role.id}},
+      headers:, as: :json
+  end
+
+  it "counts a wrong current_password toward lockout" do
+    attempt("WrongPassword999!")
+
+    expect(response).to have_http_status(401)
+    expect(admin.reload.failed_attempts).to eq(1)
+  end
+
+  it "locks the account after maximum_attempts" do
+    Devise.maximum_attempts.times { attempt("WrongPassword999!") }
+
+    expect(admin.reload).to be_access_locked
+  end
+
+  it "rejects a correct current_password while locked" do
+    admin.lock_access!
+
+    expect { attempt(password) }.not_to change(UserRole, :count)
+
+    expect(response).to have_http_status(401)
+  end
+
+  it "resets failed_attempts on success" do
+    admin.update_column(:failed_attempts, 2)
+
+    attempt(password)
+
+    expect(response).to have_http_status(:created)
+    expect(admin.reload.failed_attempts).to eq(0)
+  end
+
+  it "does not count a missing current_password" do
+    post "/user_roles",
+      params: {user_role: {user_id: target.id, role_id: role.id}},
+      headers:, as: :json
+
+    expect(response).to have_http_status(401)
+    expect(admin.reload.failed_attempts).to eq(0)
+  end
+end

--- a/spec/requests/current_password_gate_throttling_spec.rb
+++ b/spec/requests/current_password_gate_throttling_spec.rb
@@ -42,13 +42,21 @@ RSpec.describe "Current password gate throttling", type: :request do
     expect(admin.reload.failed_attempts).to eq(1)
   end
 
+  it "rejects a wrong current_password without locking below the threshold" do
+    (Devise.maximum_attempts - 1).times { attempt("WrongPassword999!") }
+
+    expect(response).to have_http_status(401)
+    expect(admin.reload.failed_attempts).to eq(Devise.maximum_attempts - 1)
+    expect(admin.reload).not_to be_access_locked
+  end
+
   it "locks the account after maximum_attempts" do
     Devise.maximum_attempts.times { attempt("WrongPassword999!") }
 
     expect(admin.reload).to be_access_locked
   end
 
-  it "rejects a correct current_password while locked" do
+  it "rejects a request from a locked account" do
     admin.lock_access!
 
     expect { attempt(password) }.not_to change(UserRole, :count)

--- a/spec/requests/email_change_requires_current_password_spec.rb
+++ b/spec/requests/email_change_requires_current_password_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Email change requires current password", type: :request do
+  let(:password) { "SecurePassword123!" }
+  let(:admin) { FactoryBot.create(:user, :admin, password:, password_confirmation: password) }
+
+  before do
+    allow_any_instance_of(UserPolicy).to receive(:permitted_attributes)
+      .and_return([:name, :email])
+  end
+
+  def sign_in_headers
+    allow(Rails.application.config).to receive(:enable_mfa).and_return(false)
+    post "/auth/sign_in", params: {email: admin.email, password:}, as: :json
+    expect(response).to have_http_status(:success)
+    {
+      "access-token" => response.headers["access-token"],
+      "client" => response.headers["client"],
+      "uid" => response.headers["uid"]
+    }
+  end
+
+  it "rejects an email change without current_password" do
+    headers = sign_in_headers
+
+    put "/users/#{admin.id}",
+      params: {user: {email: "new@example.com"}}, headers:, as: :json
+
+    expect(response).to have_http_status(401)
+    expect(admin.reload.email).not_to eq("new@example.com")
+  end
+
+  it "allows an email change with correct current_password" do
+    headers = sign_in_headers
+
+    put "/users/#{admin.id}",
+      params: {current_password: password, user: {email: "new@example.com"}},
+      headers:, as: :json
+
+    expect(response).to have_http_status(:success)
+    expect(admin.reload.email).to eq("new@example.com")
+  end
+
+  it "does not require current_password for a name-only update" do
+    headers = sign_in_headers
+
+    put "/users/#{admin.id}",
+      params: {user: {name: "New Name"}}, headers:, as: :json
+
+    expect(response).to have_http_status(:success)
+    expect(admin.reload.name).to eq("New Name")
+  end
+end

--- a/spec/requests/password_change_requires_current_password_spec.rb
+++ b/spec/requests/password_change_requires_current_password_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe "In-app password change requires current password", type: :reques
     expect(user.reload.valid_password?(new_password)).to be(false)
   end
 
+  it "rejects a password change with an incorrect current_password" do
+    headers = sign_in_headers
+
+    put "/auth",
+      params: {
+        current_password: "WrongPassword999!",
+        password: new_password,
+        password_confirmation: new_password
+      },
+      headers: headers, as: :json
+
+    expect(response).to have_http_status(422)
+    expect(user.reload.valid_password?(current_password)).to be(true)
+    expect(user.reload.valid_password?(new_password)).to be(false)
+  end
+
   it "allows a password change with the correct current_password" do
     headers = sign_in_headers
 

--- a/spec/requests/password_change_requires_current_password_spec.rb
+++ b/spec/requests/password_change_requires_current_password_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "In-app password change requires current password", type: :request do
+  let(:current_password) { "SecurePassword123!" }
+  let(:new_password) { "SecurePassword456!" }
+
+  let(:user) do
+    FactoryBot.create(:user, password: current_password, password_confirmation: current_password)
+  end
+
+  def sign_in_headers
+    allow(Rails.application.config).to receive(:enable_mfa).and_return(false)
+    post "/auth/sign_in", params: {email: user.email, password: current_password}, as: :json
+    expect(response).to have_http_status(:success)
+    {
+      "access-token" => response.headers["access-token"],
+      "client" => response.headers["client"],
+      "uid" => response.headers["uid"]
+    }
+  end
+
+  it "rejects a password change without current_password" do
+    headers = sign_in_headers
+
+    put "/auth",
+      params: {password: new_password, password_confirmation: new_password},
+      headers: headers, as: :json
+
+    expect(response).to have_http_status(422)
+    expect(user.reload.valid_password?(current_password)).to be(true)
+    expect(user.reload.valid_password?(new_password)).to be(false)
+  end
+
+  it "allows a password change with the correct current_password" do
+    headers = sign_in_headers
+
+    put "/auth",
+      params: {
+        current_password: current_password,
+        password: new_password,
+        password_confirmation: new_password
+      },
+      headers: headers, as: :json
+
+    expect(response).to have_http_status(:success)
+    expect(user.reload.valid_password?(new_password)).to be(true)
+  end
+end

--- a/spec/requests/swagger/user_role_spec.rb
+++ b/spec/requests/swagger/user_role_spec.rb
@@ -111,25 +111,20 @@ RSpec.describe "User Roles API", type: :request do
     delete "Delete a user role" do
       tags "User Roles"
       security [{access_token: [], client: [], uid: []}]
-      # current_password is sent in the request body by the client; documented as a
-      # query param here only because the rswag/rack-test harness doesn't send DELETE
-      # bodies. The controller reads params[:current_password] from either source.
-      parameter name: :current_password, in: :query, required: false, type: :string,
-        description: "Current password for re-authentication. The client sends this in the request body; documented as a query parameter here due to a test-harness limitation with DELETE bodies. The server reads it from either."
+
+      # No 204 example: rswag does not send a request body on DELETE, so the
+      # re-authentication gate rejects it. Success path is covered in
+      # spec/requests/user_roles_require_current_password_spec.rb.
+      parameter name: :user_role, in: :body, schema: {
+        type: :object,
+        properties: {
+          current_password: {type: :string}
+        },
+        required: ["current_password"]
+      }
 
       include_examples "swagger 401" do
         let(:id) { FactoryBot.create(:user, :contributor).user_roles.first.id }
-      end
-
-      response "204", "admin removes a role" do
-        let(:auth) { auth_headers_for(admin) }
-        let(:"access-token") { auth["access-token"] }
-        let(:client) { auth["client"] }
-        let(:uid) { auth["uid"] }
-        let(:id) { FactoryBot.create(:user, :contributor).user_roles.first.id }
-        let(:current_password) { "SecurePassword123!" }
-
-        run_test!
       end
 
       include_examples "swagger 403 forbidden" do

--- a/spec/requests/swagger/user_role_spec.rb
+++ b/spec/requests/swagger/user_role_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "User Roles API", type: :request do
       parameter name: :user_role, in: :body, schema: {
         type: :object,
         properties: {
+          current_password: {type: :string},
           user_role: {
             type: :object,
             properties: {
@@ -72,6 +73,15 @@ RSpec.describe "User Roles API", type: :request do
         let(:"access-token") { auth["access-token"] }
         let(:client) { auth["client"] }
         let(:uid) { auth["uid"] }
+        let(:user_role) {
+          {
+            current_password: "SecurePassword123!",
+            user_role: {
+              user_id: target_user.id,
+              role_id: contributor_role.id
+            }
+          }
+        }
 
         run_test!
       end
@@ -84,7 +94,7 @@ RSpec.describe "User Roles API", type: :request do
         let(:client) { auth["client"] }
         let(:uid) { auth["uid"] }
         let(:user_role) {
-          {user_role: {user_id: nil, role_id: nil}}
+          {current_password: "SecurePassword123!", user_role: {user_id: nil, role_id: nil}}
         }
 
         run_test!
@@ -101,6 +111,11 @@ RSpec.describe "User Roles API", type: :request do
     delete "Delete a user role" do
       tags "User Roles"
       security [{access_token: [], client: [], uid: []}]
+      # current_password is sent in the request body by the client; documented as a
+      # query param here only because the rswag/rack-test harness doesn't send DELETE
+      # bodies. The controller reads params[:current_password] from either source.
+      parameter name: :current_password, in: :query, required: false, type: :string,
+        description: "Current password for re-authentication. The client sends this in the request body; documented as a query parameter here due to a test-harness limitation with DELETE bodies. The server reads it from either."
 
       include_examples "swagger 401" do
         let(:id) { FactoryBot.create(:user, :contributor).user_roles.first.id }
@@ -112,6 +127,7 @@ RSpec.describe "User Roles API", type: :request do
         let(:client) { auth["client"] }
         let(:uid) { auth["uid"] }
         let(:id) { FactoryBot.create(:user, :contributor).user_roles.first.id }
+        let(:current_password) { "SecurePassword123!" }
 
         run_test!
       end

--- a/spec/requests/user_roles_require_current_password_spec.rb
+++ b/spec/requests/user_roles_require_current_password_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Role changes require current password", type: :request do
+  let(:password) { "SecurePassword123!" }
+  let(:admin) { FactoryBot.create(:user, :admin, password:, password_confirmation: password) }
+  let(:target) { FactoryBot.create(:user) }
+  let(:role) { FactoryBot.create(:role, :contributor) }
+
+  def sign_in_headers
+    allow(Rails.application.config).to receive(:enable_mfa).and_return(false)
+    post "/auth/sign_in", params: {email: admin.email, password:}, as: :json
+    expect(response).to have_http_status(:success)
+    {
+      "access-token" => response.headers["access-token"],
+      "client" => response.headers["client"],
+      "uid" => response.headers["uid"]
+    }
+  end
+
+  describe "POST /user_roles" do
+    it "rejects without current_password" do
+      headers = sign_in_headers
+
+      expect {
+        post "/user_roles",
+          params: {user_role: {user_id: target.id, role_id: role.id}},
+          headers:, as: :json
+      }.not_to change(UserRole, :count)
+
+      expect(response).to have_http_status(401)
+    end
+
+    it "allows with correct current_password" do
+      headers = sign_in_headers
+
+      expect {
+        post "/user_roles",
+          params: {current_password: password, user_role: {user_id: target.id, role_id: role.id}},
+          headers:, as: :json
+      }.to change(UserRole, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+    end
+  end
+
+  describe "DELETE /user_roles/:id" do
+    let!(:user_role) { UserRole.create!(user: target, role: role) }
+
+    it "rejects without current_password" do
+      headers = sign_in_headers
+
+      expect {
+        delete "/user_roles/#{user_role.id}", headers:, as: :json
+      }.not_to change(UserRole, :count)
+
+      expect(response).to have_http_status(401)
+    end
+
+    it "allows with correct current_password" do
+      headers = sign_in_headers
+
+      expect {
+        delete "/user_roles/#{user_role.id}",
+          params: {current_password: password}, headers:, as: :json
+      }.to change(UserRole, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end


### PR DESCRIPTION
Adds re-authentication (current password) to sensitive account actions, so a session cannot make them without the acting user proving their identity. 

Changes:

- Password change: sets config.check_current_password_before_update = :password. Previously current_password was validated only if supplied; omitting it bypassed the check. Now it is required whenever the password changes. The token-based reset flow stays exempt (allow_password_change bypasses the check in DTA).

- Role changes: require_current_password! gates all role assignment and removal on UserRolesController (not just promotions, so it stays correct if non-hierarchical roles are added later). Re-authentication runs after authorization, so a user who isn't permitted to change roles gets 403 (forbidden) rather than being prompted for a password.

- Email change: same gate on UsersController#update, but only when the email is actually changing. Dormant for SG (update_email is disabled, so email is stripped from permitted attributes); active on installs that enable email editing.

The gate (require_current_password! in ApplicationController) is defence-in-depth: the client sends current_password on these requests, so it primarily blocks direct API calls (e.g. a hijacked session).

Existing UserRoles controller and API specs updated to send current_password on the success cases and to reflect the authorization-before-re-authentication ordering.

Verified on UAT: password change and role assign/remove reject without current_password (401/422) and succeed with it. Email gate covered by spec (stubbed on), since it is disabled on this build.

Depends on #508. Based on that branch; the email gate builds on its permitted-attributes change.

Client side implementation still TODO