### PR TITLE
Remove generator default overriding navigational_formats 

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -231,17 +231,6 @@ Devise.setup do |config|
   # only the current scope. By default, Devise signs out all scopes.
   # config.sign_out_all_scopes = true
 
-  # ==> Navigation configuration
-  # Lists the formats that should be treated as navigational. Formats like
-  # :html, should redirect to the sign in page when the user does not have
-  # access, but formats like :xml or :json, should return 401.
-  #
-  # If you have any extra navigational formats, like :iphone or :mobile, you
-  # should add them to the navigational formats lists.
-  #
-  # The "*/*" below is required to match Internet Explorer requests.
-  config.navigational_formats = ["*/*", :html]
-
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete
 


### PR DESCRIPTION
`config/initializers/devise.rb` sets `navigational_formats` twice. An earlier line sets it to `[]` (alongside `skip_session_storage = [:http_auth, :token_auth]`), which is the intended API-only behaviour. The generator's stock block further down then overrides it with `["*/*", :html]`.

With `*/*` treated as navigational, Devise's failure app takes the redirect branch on auth failure. On GET requests it calls `store_location!`, which writes to the session - disabled on this app - raising `DisabledSessionError`. So a GET auth failure without a JSON `Accept` header returns 500 instead of 401. POST failures return 302 (no session write, since `store_location!` only stores on GET).

Not reachable from the SPA, which sends `Accept: application/json` and gets 401 as expected. Surfaced via curl.

**Change:** delete the duplicate assignment and its boilerplate comment, leaving `[]` as the effective value. No sign-in page exists on this API-only backend to redirect to.

**Verified on UAT:** locked account with a valid token, `GET /users`, no `Accept` header - 500 (`DisabledSessionError`) before, 401 after. JSON `Accept` path unchanged.

**Note:** the 401 now carries `content-type: */*; charset=utf-8` (echoing `request.format`). Cosmetic - body is still JSON.

Independent of #508/#512; branched off `sg-dev`.